### PR TITLE
[feat] 텍스트 유사도 검색 구현을 위한 Cosine Similarity와 TF-IDF

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,4 +38,5 @@ out/
 
 .ap
 
-./resurces/application-dev.yml
+./resurces/application-dev.yml!/docker/db/
+!/db/

--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,15 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+    // open korean text
+    implementation 'org.openkoreantext:open-korean-text:2.1.0'
+    // Apache Commons Lang의 LevenshteinDistance
+    implementation 'org.apache.commons:commons-lang3:3.12.0'
+    implementation 'org.apache.commons:commons-text:1.10.0'
+
+    implementation 'org.apache.lucene:lucene-core:6.6.1'
+    implementation 'org.apache.lucene:lucene-analyzers-common:6.6.1'
 }
 
 tasks.named('test') {

--- a/compose-local.yaml
+++ b/compose-local.yaml
@@ -5,12 +5,14 @@ services:
     ports:
       - "3316:3306"
     environment:
-      MYSQL_ROOT_PASSWORD: maruegg!
+      MYSQL_ROOT_PASSWORD:
       MYSQL_DATABASE: maru-egg-db
-      MYSQL_USER: maruegg
-      MYSQL_PASSWORD: maruegg!
+      MYSQL_USER:
+      MYSQL_PASSWORD:
       TZ: Asia/Seoul
     volumes:
       - ./db/mysql/data:/var/lib/mysql
       - ./db/mysql/config:/etc/mysql/conf.d
       - ./db/mysql/init:/docker-entrypoint-initdb.d
+    command:
+      - "--innodb_ft_min_token_size=1"

--- a/src/main/java/mju/iphak/maru_egg/question/domain/Question.java
+++ b/src/main/java/mju/iphak/maru_egg/question/domain/Question.java
@@ -20,4 +20,5 @@ public class Question extends BaseEntity {
 	private String content;
 	private QuestionType questionType;
 	private QuestionCategory questionCategory;
+	private String lastUpdatedYear;
 }

--- a/src/main/java/mju/iphak/maru_egg/question/domain/QuestionCategory.java
+++ b/src/main/java/mju/iphak/maru_egg/question/domain/QuestionCategory.java
@@ -4,9 +4,9 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public enum QuestionCategory {
-	ADMISSIONS_TIMELINE("전형 일정"),
-	QUALIFICATION("지원자격"),
-	DOCUMENTATION("제출서류"),
+	ADMISSION_GUIDELINE("모집요강"),
+	PASSING_RESULT("입시결과"),
+	PAST_QUESTIONS("기출문제"),
 	UNIV_LIFE("대학생활"),
 	INTERVIEW_PRACTICAL_TEST("면접/실기"),
 	ETC("기타");

--- a/src/main/java/mju/iphak/maru_egg/question/utils/CustomTFIDFSimilarity.java
+++ b/src/main/java/mju/iphak/maru_egg/question/utils/CustomTFIDFSimilarity.java
@@ -1,0 +1,52 @@
+package mju.iphak.maru_egg.question.utils;
+
+import org.apache.lucene.index.FieldInvertState;
+import org.apache.lucene.search.similarities.TFIDFSimilarity;
+import org.apache.lucene.util.BytesRef;
+
+public class CustomTFIDFSimilarity extends TFIDFSimilarity {
+	@Override
+	public float coord(int overlap, int maxOverlap) {
+		return overlap / (float)maxOverlap;
+	}
+
+	@Override
+	public float queryNorm(float sumOfSquaredWeights) {
+		return 1.0f;
+	}
+
+	@Override
+	public float tf(float freq) {
+		return (float)Math.sqrt(freq);
+	}
+
+	@Override
+	public float idf(long docFreq, long docCount) {
+		return (float)(Math.log((docCount + 1) / (double)(docFreq + 1)) + 1.0);
+	}
+
+	@Override
+	public float lengthNorm(FieldInvertState state) {
+		return 1 / (float)Math.sqrt(state.getLength());
+	}
+
+	@Override
+	public float sloppyFreq(int distance) {
+		return 1.0f;
+	}
+
+	@Override
+	public float scorePayload(int doc, int start, int end, BytesRef payload) {
+		return 1.0f;
+	}
+
+	@Override
+	public float decodeNormValue(long norm) {
+		return 1.0f;
+	}
+
+	@Override
+	public long encodeNormValue(float f) {
+		return 1L;
+	}
+}

--- a/src/main/java/mju/iphak/maru_egg/question/utils/PhraseExtractionUtils.java
+++ b/src/main/java/mju/iphak/maru_egg/question/utils/PhraseExtractionUtils.java
@@ -1,0 +1,27 @@
+package mju.iphak.maru_egg.question.utils;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.openkoreantext.processor.OpenKoreanTextProcessorJava;
+import org.openkoreantext.processor.tokenizer.KoreanTokenizer;
+
+import scala.collection.JavaConverters;
+import scala.collection.Seq;
+
+public class PhraseExtractionUtils {
+	public static List<String> extractTokens(List<KoreanTokenizer.KoreanToken> tokens) {
+		return tokens.stream()
+			.filter(token -> token.pos().toString().equals("Noun"))
+			.map(token -> token.text().toString())
+			.collect(Collectors.toList());
+	}
+
+	public static String extractPhrases(String text) {
+		CharSequence normalized = OpenKoreanTextProcessorJava.normalize(text);
+		Seq<KoreanTokenizer.KoreanToken> tokens = OpenKoreanTextProcessorJava.tokenize(normalized);
+		List<KoreanTokenizer.KoreanToken> tokenList = JavaConverters.seqAsJavaList(tokens);
+		List<String> phrases = extractTokens(tokenList);
+		return String.join(" ", phrases);
+	}
+}

--- a/src/main/java/mju/iphak/maru_egg/question/utils/TextSimilarityUtils.java
+++ b/src/main/java/mju/iphak/maru_egg/question/utils/TextSimilarityUtils.java
@@ -1,0 +1,58 @@
+package mju.iphak.maru_egg.question.utils;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.text.similarity.CosineSimilarity;
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.core.WhitespaceAnalyzer;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.TextField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.similarities.TFIDFSimilarity;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.RAMDirectory;
+
+public class TextSimilarityUtils {
+
+	public static double computeCosineSimilarity(Map<CharSequence, Integer> vec1, Map<CharSequence, Integer> vec2) {
+		CosineSimilarity cosineSimilarity = new CosineSimilarity();
+		return cosineSimilarity.cosineSimilarity(vec1, vec2);
+	}
+
+	public static Map<CharSequence, Integer> computeTfIdf(List<String> documents, String query) throws Exception {
+		Analyzer analyzer = new WhitespaceAnalyzer();
+		Directory directory = new RAMDirectory();
+		IndexWriterConfig config = new IndexWriterConfig(analyzer);
+		try (IndexWriter indexWriter = new IndexWriter(directory, config)) {
+			for (String document : documents) {
+				Document doc = new Document();
+				doc.add(new TextField("content", document, Field.Store.YES));
+				indexWriter.addDocument(doc);
+			}
+		}
+
+		try (IndexReader reader = DirectoryReader.open(directory)) {
+			TFIDFSimilarity tfidfSimilarity = new CustomTFIDFSimilarity();
+			Map<CharSequence, Integer> tfidfMap = new HashMap<>();
+			List<String> terms = Arrays.asList(query.split("\\s+"));
+
+			for (String term : terms) {
+				int docFreq = reader.docFreq(new Term("content", term));
+				float idf = tfidfSimilarity.idf(docFreq, reader.maxDoc());
+				tfidfMap.put(term, (int)idf);
+			}
+
+			return tfidfMap;
+		} finally {
+			directory.close();
+		}
+	}
+}

--- a/src/test/java/mju/iphak/maru_egg/question/utils/TextSimilarityUtilsTest.java
+++ b/src/test/java/mju/iphak/maru_egg/question/utils/TextSimilarityUtilsTest.java
@@ -1,0 +1,91 @@
+package mju.iphak.maru_egg.question.utils;
+
+import static mju.iphak.maru_egg.question.utils.PhraseExtractionUtils.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class TextSimilarityUtilsTest {
+
+	private static List<String> documents;
+
+	@BeforeAll
+	public static void setUp() {
+		documents = Arrays.asList(
+			extractPhrases("수시 원서접수 기간 알려줘"),
+			extractPhrases("수시 모집기간 알려줘"),
+			extractPhrases("수시 모집 알려줘"),
+			extractPhrases("수시 원서접수 기간 알려줘"),
+			extractPhrases("수시 원서 접수"),
+			extractPhrases("수시 원서"),
+			extractPhrases("정시 원서 기간 알려줘"),
+			extractPhrases("정시 원서 접수 기간이 언제야?"),
+			extractPhrases("정시 원서"),
+			extractPhrases("정시 원서 기간"),
+			extractPhrases("입학 시험은 무엇이 필요한가요?'"),
+			extractPhrases("입학 시험 필요한거 내놔")
+		);
+	}
+
+	@DisplayName("유사도가 가장 높은 문장 찾기")
+	@ParameterizedTest(name = "{index} => input={0}")
+	@MethodSource("inputQuestions")
+	public void 유사도가_가장_높은_문장_찾기(String input, boolean expectedBoolean) throws Exception {
+		String inputPhrases = extractPhrases(input);
+		double maxSimilarity = -1;
+		String mostSimilarDocument = null;
+
+		for (String document : documents) {
+			Map<CharSequence, Integer> tfIdf1 = TextSimilarityUtils.computeTfIdf(documents, inputPhrases);
+			Map<CharSequence, Integer> tfIdf2 = TextSimilarityUtils.computeTfIdf(documents, document);
+
+			double similarity = TextSimilarityUtils.computeCosineSimilarity(tfIdf1, tfIdf2);
+
+			if (similarity > maxSimilarity) {
+				maxSimilarity = similarity;
+				mostSimilarDocument = document;
+			}
+		}
+
+		System.out.println("============================================================");
+		System.out.println("Input: " + input);
+		System.out.println("Most Similar Document: " + mostSimilarDocument);
+		System.out.println("Similarity: " + maxSimilarity);
+		System.out.println("============================================================\n");
+
+		assertNotNull(mostSimilarDocument, "There should be a most similar document.");
+		assertThat(expectedBoolean).isEqualTo(maxSimilarity >= 0.95);
+	}
+
+	private static Stream<Arguments> inputQuestions() {
+		return Stream.of(
+			Arguments.of("수시에서 모집 기간 알려주세욬ㅋㅋㅋ", true),
+			Arguments.of("수시 지원 마감일은 언제인가요?", false),
+			Arguments.of("수시 마감일", false),
+			Arguments.of("수시 지원서 제출", false),
+			Arguments.of("수시 원서 접수 기간", true),
+			Arguments.of("수시 지원서 제출 기간", false),
+			Arguments.of("수시 제출", false),
+			Arguments.of("수시 지원서", false),
+			Arguments.of("정시 원서접수 기간 알려줘", false),
+			Arguments.of("정시 지원 마감일은 언제인가요?", false),
+			Arguments.of("정시 마감일", false),
+			Arguments.of("정시 지원서 제출", false),
+			Arguments.of("정시 원서 접수 기간", false),
+			Arguments.of("정시 지원서 제출 기간", false),
+			Arguments.of("정시 제출", false),
+			Arguments.of("정시 지원서", false),
+			Arguments.of("입학 시험", true)
+		);
+	}
+}


### PR DESCRIPTION
## ✅ 작업 내용
- Cosine Similarity와 TF-IDF를 이용한 텍스트 유사도를 검색할 수 있도록 기능을 구현했습니다.
- 이에 대한 테스트와 문서를 정리했습니다.

## 🤔 고민 했던 부분
- Elasticsearch를 사용하는 것이 나을지 MySQL의 Full Text Index를 사용하는 것이 나을지 고민했습니다.
[프로젝트 | 텍스트 유사도 검색 어떻게 구현할까?(1) - Elasticsearch를 안 쓴 이유와 MySQL Full Text Index](https://hoya324.tistory.com/56) 해당 블로그는 이에 대해 고민한 내용을 정리한 문서입니다.
- 어떤 방식으로 한글 문장의 유사도를 측정해야할지 고민했고, Cosine Similarity와 TF-IDF를 어떤 방식으로 적용할지 고민했스빈다.
[프로젝트 | 텍스트 유사도 검색 어떻게 구현할까?(2) - Cosine Similarity과 TF-IDF](https://hoya324.tistory.com/57) 해당 블로그는 이에 대해 고민한 내용을 정리한 문서입니다.