### PR TITLE
[feat] question 초기 api

### DIFF
--- a/src/main/java/mju/iphak/maru_egg/answer/application/AnswerService.java
+++ b/src/main/java/mju/iphak/maru_egg/answer/application/AnswerService.java
@@ -1,0 +1,25 @@
+package mju.iphak.maru_egg.answer.application;
+
+import static mju.iphak.maru_egg.common.exception.ErrorCode.*;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import mju.iphak.maru_egg.answer.domain.Answer;
+import mju.iphak.maru_egg.answer.repository.AnswerRepository;
+
+@RequiredArgsConstructor
+@Service
+@Transactional(readOnly = true)
+public class AnswerService {
+
+	private final AnswerRepository answerRepository;
+
+	public Answer getAnswerByQuestionId(Long questionId) {
+		return answerRepository.findByQuestionId(questionId)
+			.orElseThrow(() -> new EntityNotFoundException(
+				String.format(NOT_FOUND_ANSWER.getMessage(), questionId)));
+	}
+}

--- a/src/main/java/mju/iphak/maru_egg/answer/domain/Answer.java
+++ b/src/main/java/mju/iphak/maru_egg/answer/domain/Answer.java
@@ -1,5 +1,7 @@
 package mju.iphak.maru_egg.answer.domain;
 
+import java.time.LocalDate;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -25,7 +27,27 @@ public class Answer extends BaseEntity {
 	@Column(nullable = false, length = 4000)
 	private String content;
 
+	@Column(nullable = false)
+	private int renewalYear;
+
 	@OneToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "question_id", nullable = false)
 	private Question question;
+
+	public String getDateInformation() {
+		return "생성일자: %s, 마지막 DB 갱신일자: %s".formatted(this.getCreatedAt(), this.getUpdatedAt());
+	}
+
+	public static Answer of(Question question, String content) {
+		return Answer.builder()
+			.content(content)
+			.renewalYear(getNowYear())
+			.question(question)
+			.build();
+	}
+
+	private static int getNowYear() {
+		LocalDate nowDate = LocalDate.now();
+		return Integer.parseInt(String.valueOf(nowDate.getYear()));
+	}
 }

--- a/src/main/java/mju/iphak/maru_egg/answer/dto/response/AnswerResponse.java
+++ b/src/main/java/mju/iphak/maru_egg/answer/dto/response/AnswerResponse.java
@@ -1,0 +1,30 @@
+package mju.iphak.maru_egg.answer.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import mju.iphak.maru_egg.answer.domain.Answer;
+
+@Builder
+@Schema(description = "답변 DTO")
+public record AnswerResponse(
+	@Schema(description = "답변 id")
+	Long id,
+
+	@Schema(description = "답변 내용")
+	String content,
+
+	@Schema(description = "답변 갱신 년도")
+	int renewalYear,
+
+	@Schema(description = "답변 DB 생성 및 업데이트 날짜")
+	String dateInformation
+) {
+	public static AnswerResponse from(Answer answer) {
+		return AnswerResponse.builder()
+			.id(answer.getId())
+			.content(answer.getContent())
+			.renewalYear(answer.getRenewalYear())
+			.dateInformation(answer.getDateInformation())
+			.build();
+	}
+}

--- a/src/main/java/mju/iphak/maru_egg/answer/repository/AnswerRepository.java
+++ b/src/main/java/mju/iphak/maru_egg/answer/repository/AnswerRepository.java
@@ -1,8 +1,11 @@
 package mju.iphak.maru_egg.answer.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import mju.iphak.maru_egg.answer.domain.Answer;
 
 public interface AnswerRepository extends JpaRepository<Answer, Long> {
+	Optional<Answer> findByQuestionId(Long id);
 }

--- a/src/main/java/mju/iphak/maru_egg/common/exception/ErrorCode.java
+++ b/src/main/java/mju/iphak/maru_egg/common/exception/ErrorCode.java
@@ -14,8 +14,8 @@ public enum ErrorCode {
 	// 400 error
 
 	// 404 error
-	NOT_FOUND_CHAT(NOT_FOUND, "id: %s인 채팅방을 찾을 수 없습니다."),
-	NOT_FOUND_CHAT_MESSAGE_IN_CHAT(NOT_FOUND, "id: %s인 채팅방의 채팅을 찾을 수 없습니다.");
+	NOT_FOUND_QUESTION(NOT_FOUND, "type: %s, category: %s, content: %s인 질문을 찾을 수 없습니다."),
+	NOT_FOUND_ANSWER(NOT_FOUND, "질문 id가 %s인 답변을 찾을 수 없습니다.");
 
 	// 500 error
 

--- a/src/main/java/mju/iphak/maru_egg/question/api/QuestionController.java
+++ b/src/main/java/mju/iphak/maru_egg/question/api/QuestionController.java
@@ -1,18 +1,26 @@
 package mju.iphak.maru_egg.question.api;
 
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import mju.iphak.maru_egg.question.application.QuestionService;
+import mju.iphak.maru_egg.question.dto.request.QuestionRequest;
+import mju.iphak.maru_egg.question.dto.response.QuestionResponse;
 
 @Tag(name = "Question API", description = "질문 관련 API 입니다.")
+@RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/questions")
 public class QuestionController {
 
-	@GetMapping()
-	public String getQuestion() {
-		return "아 됐다. 휴";
+	private final QuestionService questionService;
+
+	@PostMapping()
+	public QuestionResponse question(@RequestBody QuestionRequest request) {
+		return questionService.getQuestionResponse(request.type(), request.category(), request.content());
 	}
 }

--- a/src/main/java/mju/iphak/maru_egg/question/application/QuestionService.java
+++ b/src/main/java/mju/iphak/maru_egg/question/application/QuestionService.java
@@ -7,9 +7,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import mju.iphak.maru_egg.answer.application.AnswerService;
 import mju.iphak.maru_egg.answer.domain.Answer;
 import mju.iphak.maru_egg.answer.dto.response.AnswerResponse;
-import mju.iphak.maru_egg.answer.repository.AnswerRepository;
 import mju.iphak.maru_egg.question.domain.Question;
 import mju.iphak.maru_egg.question.domain.QuestionCategory;
 import mju.iphak.maru_egg.question.domain.QuestionType;
@@ -22,7 +22,7 @@ import mju.iphak.maru_egg.question.repository.QuestionRepository;
 public class QuestionService {
 
 	private final QuestionRepository questionRepository;
-	private final AnswerRepository answerRepository;
+	private final AnswerService answerService;
 
 	// TODO: 질문이 이미 존재하는지 확인 (유사도 검사)
 	public QuestionResponse getQuestionResponse(final QuestionType type, final QuestionCategory category,
@@ -33,9 +33,7 @@ public class QuestionService {
 			.orElseThrow(() -> new EntityNotFoundException(
 				String.format(NOT_FOUND_QUESTION.getMessage(), type, category, content)));
 
-		Answer answer = answerRepository.findByQuestionId(question.getId())
-			.orElseThrow(() -> new EntityNotFoundException(
-				String.format(NOT_FOUND_ANSWER.getMessage(), question.getId())));
+		Answer answer = answerService.getAnswerByQuestionId(question.getId());
 
 		AnswerResponse answerResponse = AnswerResponse.from(answer);
 		return QuestionResponse.of(question, answerResponse);

--- a/src/main/java/mju/iphak/maru_egg/question/application/QuestionService.java
+++ b/src/main/java/mju/iphak/maru_egg/question/application/QuestionService.java
@@ -1,0 +1,43 @@
+package mju.iphak.maru_egg.question.application;
+
+import static mju.iphak.maru_egg.common.exception.ErrorCode.*;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import mju.iphak.maru_egg.answer.domain.Answer;
+import mju.iphak.maru_egg.answer.dto.response.AnswerResponse;
+import mju.iphak.maru_egg.answer.repository.AnswerRepository;
+import mju.iphak.maru_egg.question.domain.Question;
+import mju.iphak.maru_egg.question.domain.QuestionCategory;
+import mju.iphak.maru_egg.question.domain.QuestionType;
+import mju.iphak.maru_egg.question.dto.response.QuestionResponse;
+import mju.iphak.maru_egg.question.repository.QuestionRepository;
+
+@RequiredArgsConstructor
+@Service
+@Transactional(readOnly = true)
+public class QuestionService {
+
+	private final QuestionRepository questionRepository;
+	private final AnswerRepository answerRepository;
+
+	// TODO: 질문이 이미 존재하는지 확인 (유사도 검사)
+	public QuestionResponse getQuestionResponse(final QuestionType type, final QuestionCategory category,
+		final String content) {
+
+		Question question = questionRepository.findByContentAndQuestionCategoryAndQuestionType(
+				content, category, type)
+			.orElseThrow(() -> new EntityNotFoundException(
+				String.format(NOT_FOUND_QUESTION.getMessage(), type, category, content)));
+
+		Answer answer = answerRepository.findByQuestionId(question.getId())
+			.orElseThrow(() -> new EntityNotFoundException(
+				String.format(NOT_FOUND_ANSWER.getMessage(), question.getId())));
+
+		AnswerResponse answerResponse = AnswerResponse.from(answer);
+		return QuestionResponse.of(question, answerResponse);
+	}
+}

--- a/src/main/java/mju/iphak/maru_egg/question/domain/Question.java
+++ b/src/main/java/mju/iphak/maru_egg/question/domain/Question.java
@@ -20,5 +20,16 @@ public class Question extends BaseEntity {
 	private String content;
 	private QuestionType questionType;
 	private QuestionCategory questionCategory;
-	private String lastUpdatedYear;
+
+	public String getDateInformation() {
+		return "생성일자: %s, 마지막 DB 갱신일자: %s".formatted(this.getCreatedAt(), this.getUpdatedAt());
+	}
+
+	public static Question of(String content, QuestionType questionType, QuestionCategory questionCategory) {
+		return Question.builder()
+			.content(content)
+			.questionType(questionType)
+			.questionCategory(questionCategory)
+			.build();
+	}
 }

--- a/src/main/java/mju/iphak/maru_egg/question/domain/QuestionCategory.java
+++ b/src/main/java/mju/iphak/maru_egg/question/domain/QuestionCategory.java
@@ -1,7 +1,9 @@
 package mju.iphak.maru_egg.question.domain;
 
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+@Getter
 @RequiredArgsConstructor
 public enum QuestionCategory {
 	ADMISSION_GUIDELINE("모집요강"),

--- a/src/main/java/mju/iphak/maru_egg/question/dto/request/QuestionRequest.java
+++ b/src/main/java/mju/iphak/maru_egg/question/dto/request/QuestionRequest.java
@@ -1,0 +1,19 @@
+package mju.iphak.maru_egg.question.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import mju.iphak.maru_egg.question.domain.QuestionCategory;
+import mju.iphak.maru_egg.question.domain.QuestionType;
+
+@Schema(description = "질문 생성 요청 DTO")
+public record QuestionRequest(
+
+	@Schema(description = "질문 타입(수시, 정시, 편입학, 재외국민)")
+	QuestionType type,
+
+	@Schema(description = "질문 카테고리(모집요강, 입시결과, 기출 문제)")
+	QuestionCategory category,
+
+	@Schema(description = "질문 내용")
+	String content
+) {
+}

--- a/src/main/java/mju/iphak/maru_egg/question/dto/response/QuestionResponse.java
+++ b/src/main/java/mju/iphak/maru_egg/question/dto/response/QuestionResponse.java
@@ -1,0 +1,28 @@
+package mju.iphak.maru_egg.question.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import mju.iphak.maru_egg.answer.dto.response.AnswerResponse;
+import mju.iphak.maru_egg.question.domain.Question;
+
+@Builder
+@Schema(description = "질문 응답 DTO")
+public record QuestionResponse(
+	@Schema(description = "질문 id")
+	Long id,
+
+	@Schema(description = "답변 DB 생성 및 업데이트 날짜")
+	String dateInformation,
+
+	@Schema(description = "답변 DTO")
+	AnswerResponse answer
+) {
+
+	public static QuestionResponse of(Question question, AnswerResponse answer) {
+		return QuestionResponse.builder()
+			.id(question.getId())
+			.dateInformation(question.getDateInformation())
+			.answer(answer)
+			.build();
+	}
+}

--- a/src/main/java/mju/iphak/maru_egg/question/repository/QuestionRepository.java
+++ b/src/main/java/mju/iphak/maru_egg/question/repository/QuestionRepository.java
@@ -1,8 +1,15 @@
 package mju.iphak.maru_egg.question.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import mju.iphak.maru_egg.question.domain.Question;
+import mju.iphak.maru_egg.question.domain.QuestionCategory;
+import mju.iphak.maru_egg.question.domain.QuestionType;
 
 public interface QuestionRepository extends JpaRepository<Question, Long> {
+	Optional<Question> findByContentAndQuestionCategoryAndQuestionType(final String content,
+		final QuestionCategory questionCategory,
+		final QuestionType questionType);
 }

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -4,7 +4,7 @@ spring:
   jpa:
     open-in-view: true
     hibernate:
-      ddl-auto: update # 변경: 테스트 중에 필요한 테이블을 생성하도록 설정합니다.
+      ddl-auto: update
     show-sql: true
     properties:
       hibernate:
@@ -13,7 +13,7 @@ spring:
         dialect: org.hibernate.dialect.MySQLDialect
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:tc:mysql:8.0.26:///testdb # Testcontainers URL 포맷
+    url: jdbc:tc:mysql:8.0.26:///testdb
     username: test
     password: test
 

--- a/src/test/java/mju/iphak/maru_egg/answer/repository/AnswerRepositoryTest.java
+++ b/src/test/java/mju/iphak/maru_egg/answer/repository/AnswerRepositoryTest.java
@@ -1,0 +1,67 @@
+package mju.iphak.maru_egg.answer.repository;
+
+import static mju.iphak.maru_egg.common.exception.ErrorCode.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import jakarta.persistence.EntityNotFoundException;
+import mju.iphak.maru_egg.answer.domain.Answer;
+import mju.iphak.maru_egg.common.RepositoryTest;
+import mju.iphak.maru_egg.question.domain.Question;
+import mju.iphak.maru_egg.question.domain.QuestionCategory;
+import mju.iphak.maru_egg.question.domain.QuestionType;
+import mju.iphak.maru_egg.question.repository.QuestionRepository;
+
+class AnswerRepositoryTest extends RepositoryTest {
+
+	@Autowired
+	private QuestionRepository questionRepository;
+
+	@Autowired
+	private AnswerRepository answerRepository;
+
+	@BeforeEach
+	public void setUp() throws Exception {
+		Question question = new Question("테스트 질문입니다.", QuestionType.JEONGSI, QuestionCategory.ADMISSION_GUIDELINE);
+		questionRepository.save(question);
+		Answer answer = Answer.of(question, "테스트 답변입니다.");
+		answerRepository.save(answer);
+	}
+
+	@DisplayName("답변을 조회하는데 실패한 경우-questionId을 못 찾은 경우")
+	@Test
+	void 답변_조회_실패() {
+		// given
+		Long invalidQuestionId = 100000000000L;
+
+		// when
+		Optional<Answer> answerOptional = answerRepository.findByQuestionId(invalidQuestionId);
+
+		// then
+		assertThat(answerOptional).isEmpty();
+	}
+
+	@DisplayName("답변을 조회하는데 실패한 경우-questionId을 못 찾은 경우 예외 메세지 확인")
+	@Test
+	void 답변_조회_실패_NotFound() {
+		// given
+		Long invalidQuestionId = 100000000000L;
+
+		// when & then
+		EntityNotFoundException exception = assertThrows(EntityNotFoundException.class, () -> {
+			answerRepository.findByQuestionId(invalidQuestionId)
+				.orElseThrow(() -> new EntityNotFoundException(
+					String.format(NOT_FOUND_ANSWER.getMessage(), invalidQuestionId)));
+		});
+
+		assertThat(exception.getMessage()).isEqualTo(
+			String.format(NOT_FOUND_ANSWER.getMessage(), invalidQuestionId));
+	}
+}

--- a/src/test/java/mju/iphak/maru_egg/common/IntegrationTest.java
+++ b/src/test/java/mju/iphak/maru_egg/common/IntegrationTest.java
@@ -4,6 +4,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
@@ -11,7 +12,9 @@ import org.springframework.test.web.servlet.MockMvc;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import jakarta.transaction.Transactional;
+import mju.iphak.maru_egg.TestcontainersConfiguration;
 
+@Import(TestcontainersConfiguration.class)
 @RunWith(SpringRunner.class)
 @SpringBootTest()
 @AutoConfigureMockMvc

--- a/src/test/java/mju/iphak/maru_egg/question/api/QuestionControllerTest.java
+++ b/src/test/java/mju/iphak/maru_egg/question/api/QuestionControllerTest.java
@@ -1,0 +1,70 @@
+package mju.iphak.maru_egg.question.api;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import mju.iphak.maru_egg.answer.domain.Answer;
+import mju.iphak.maru_egg.answer.dto.response.AnswerResponse;
+import mju.iphak.maru_egg.common.IntegrationTest;
+import mju.iphak.maru_egg.question.application.QuestionService;
+import mju.iphak.maru_egg.question.domain.Question;
+import mju.iphak.maru_egg.question.domain.QuestionCategory;
+import mju.iphak.maru_egg.question.domain.QuestionType;
+import mju.iphak.maru_egg.question.dto.request.QuestionRequest;
+import mju.iphak.maru_egg.question.dto.response.QuestionResponse;
+
+class QuestionControllerTest extends IntegrationTest {
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@MockBean
+	private QuestionService questionService;
+
+	@Test
+	void 질문_API() throws Exception {
+		// given
+		QuestionType type = QuestionType.SUSI;
+		QuestionCategory category = QuestionCategory.ADMISSION_GUIDELINE;
+		String content = "content";
+		Question question = Question.of(content, type, category);
+
+		Answer answer = Answer.of(question, content);
+
+		AnswerResponse answerResponse = AnswerResponse.from(answer);
+
+		QuestionRequest request = new QuestionRequest(type, category, content);
+		QuestionResponse response = QuestionResponse.of(question, answerResponse);
+
+		// when
+		when(questionService.getQuestionResponse(type, category, content)).thenReturn(response);
+		ResultActions resultActions = requestCreateQuestion(request);
+
+		// then
+		resultActions
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.id").value(question.getId()))
+			.andExpect(jsonPath("$.dateInformation").value(question.getDateInformation()))
+			.andExpect(jsonPath("$.answer.id").value(answerResponse.id()))
+			.andExpect(jsonPath("$.answer.content").value(answerResponse.content()))
+			.andExpect(jsonPath("$.answer.renewalYear").value(answerResponse.renewalYear()))
+			.andExpect(jsonPath("$.answer.dateInformation").value(answerResponse.dateInformation()));
+	}
+
+	private ResultActions requestCreateQuestion(QuestionRequest dto) throws Exception {
+		return mvc.perform(post("/api/questions")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(dto)))
+			.andDo(print());
+	}
+}

--- a/src/test/java/mju/iphak/maru_egg/question/application/QuestionServiceTest.java
+++ b/src/test/java/mju/iphak/maru_egg/question/application/QuestionServiceTest.java
@@ -1,0 +1,85 @@
+package mju.iphak.maru_egg.question.application;
+
+import static mju.iphak.maru_egg.common.exception.ErrorCode.*;
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import jakarta.persistence.EntityNotFoundException;
+import mju.iphak.maru_egg.answer.domain.Answer;
+import mju.iphak.maru_egg.answer.dto.response.AnswerResponse;
+import mju.iphak.maru_egg.answer.repository.AnswerRepository;
+import mju.iphak.maru_egg.common.MockTest;
+import mju.iphak.maru_egg.question.domain.Question;
+import mju.iphak.maru_egg.question.domain.QuestionCategory;
+import mju.iphak.maru_egg.question.domain.QuestionType;
+import mju.iphak.maru_egg.question.dto.response.QuestionResponse;
+import mju.iphak.maru_egg.question.repository.QuestionRepository;
+
+class QuestionServiceTest extends MockTest {
+
+	@Mock
+	private QuestionRepository questionRepository;
+
+	@Mock
+	private AnswerRepository answerRepository;
+
+	@InjectMocks
+	private QuestionService questionService;
+
+	private Question question;
+	private Answer answer;
+
+	@BeforeEach
+	void setUp() {
+		question = Question.of("테스트 질문입니다.", QuestionType.JEONGSI, QuestionCategory.ADMISSION_GUIDELINE);
+		answer = Answer.of(question, "테스트 답변입니다.");
+	}
+
+	@DisplayName("질문을 조회하는데 성공한 경우")
+	@Test
+	void 질문_조회_성공() {
+		// given
+		QuestionType type = QuestionType.JEONGSI;
+		QuestionCategory category = QuestionCategory.ADMISSION_GUIDELINE;
+		String content = "테스트 질문입니다.";
+
+		when(questionRepository.findByContentAndQuestionCategoryAndQuestionType(content, category, type))
+			.thenReturn(Optional.of(question));
+
+		when(answerRepository.findByQuestionId(question.getId()))
+			.thenReturn(Optional.of(answer));
+
+		// when
+		QuestionResponse result = questionService.getQuestionResponse(type, category, content);
+
+		// then
+		assertThat(result).isEqualTo(QuestionResponse.of(question, AnswerResponse.from(answer)));
+	}
+
+	@DisplayName("질문을 조회하는데 실패한 경우-question을 못 찾은 경우")
+	@Test
+	void 질문_조회_실패_NOTFOUND() {
+		// given
+		QuestionType invalidType = QuestionType.SUSI;
+		QuestionCategory category = QuestionCategory.ADMISSION_GUIDELINE;
+		String invalidContent = "invalid 질문";
+
+		// when & then
+		EntityNotFoundException exception = assertThrows(EntityNotFoundException.class, () -> {
+			questionService.getQuestionResponse(invalidType, category, invalidContent);
+		});
+
+		// when & then
+		assertThat(exception.getMessage()).isEqualTo(
+			String.format(NOT_FOUND_QUESTION.getMessage(), invalidType, category, invalidContent));
+	}
+}


### PR DESCRIPTION
## ✅ 작업 내용
- 질문 api를 위한 작업을 진행했습니다.
- swagger로 api 문서화를 했습니다.
- database에서 검색하는 부분만 구현하였습니다. (추가: 질문이 이미 존재하는지 확인 (유사도 검사))
- 구현한 로직에 대하여 integration Test, application(service) test를 mocking을 이용한 Test, repository Test를  구현했습니다.

## 🤔 고민 했던 부분
- Question과 Answer의 관계가 Request - Response의 관계라 서로의 역할을 어떤 식으로 나누어야할지 고민했습니다. 
- 이에 question은 질문에 대한 정보 및 답변에 접근하기 전까지의 책임을 부여하고, answer은 답변을 불러오는 책임을 부여했습니다.