### PR TITLE
[feat] auth (Spring Security) 기능 추가 및 question 목록 조회 API 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ jacoco {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.4.0'
     implementation 'io.hypersistence:hypersistence-utils-hibernate-60:3.5.1'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
@@ -66,6 +67,7 @@ dependencies {
 
     // open korean text
     implementation 'org.openkoreantext:open-korean-text:2.1.0'
+
     // Apache Commons Lang의 LevenshteinDistance
     implementation 'org.apache.commons:commons-lang3:3.12.0'
     implementation 'org.apache.commons:commons-text:1.10.0'
@@ -73,6 +75,9 @@ dependencies {
     // NLP
     implementation 'org.apache.lucene:lucene-core:6.6.1'
     implementation 'org.apache.lucene:lucene-analyzers-common:6.6.1'
+
+    // jwt
+    implementation 'com.auth0:java-jwt:3.4.1'
 }
 
 tasks.named('test') {

--- a/src/main/java/mju/iphak/maru_egg/auth/CustomUserDetails.java
+++ b/src/main/java/mju/iphak/maru_egg/auth/CustomUserDetails.java
@@ -1,0 +1,61 @@
+package mju.iphak.maru_egg.auth;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import lombok.Getter;
+import mju.iphak.maru_egg.user.domain.User;
+
+@Getter
+public class CustomUserDetails implements UserDetails {
+
+	private final User user;
+
+	/* 일반 로그인 생성자 */
+	public CustomUserDetails(User user) {
+		this.user = user;
+	}
+
+	/* 유저의 권한 목록, 권한 반환*/
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		Collection<GrantedAuthority> collection = new ArrayList<>();
+		;
+		collection.add(new SimpleGrantedAuthority(user.getRole().getRoleName()));
+		return collection;
+	}
+
+	@Override
+	public String getPassword() {
+		return user.getPassword();
+	}
+
+	@Override
+	public String getUsername() {
+		return user.getEmail();
+	}
+
+	@Override
+	public boolean isAccountNonExpired() {
+		return true;
+	}
+
+	@Override
+	public boolean isAccountNonLocked() {
+		return true;
+	}
+
+	@Override
+	public boolean isCredentialsNonExpired() {
+		return true;
+	}
+
+	@Override
+	public boolean isEnabled() {
+		return true;
+	}
+}

--- a/src/main/java/mju/iphak/maru_egg/auth/UserAdapter.java
+++ b/src/main/java/mju/iphak/maru_egg/auth/UserAdapter.java
@@ -1,0 +1,15 @@
+package mju.iphak.maru_egg.auth;
+
+import lombok.Getter;
+import mju.iphak.maru_egg.user.domain.User;
+
+@Getter
+public class UserAdapter extends CustomUserDetails {
+
+	private final User user;
+
+	public UserAdapter(final User user) {
+		super(user);
+		this.user = user;
+	}
+}

--- a/src/main/java/mju/iphak/maru_egg/auth/api/AuthController.java
+++ b/src/main/java/mju/iphak/maru_egg/auth/api/AuthController.java
@@ -1,0 +1,57 @@
+package mju.iphak.maru_egg.auth.api;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import mju.iphak.maru_egg.auth.application.AuthService;
+import mju.iphak.maru_egg.auth.dto.request.SignInRequest;
+import mju.iphak.maru_egg.auth.dto.request.SignUpRequest;
+import mju.iphak.maru_egg.question.meta.LoginUser;
+import mju.iphak.maru_egg.user.domain.User;
+
+@Tag(name = "Auth API", description = "인증 관련 API입니다.")
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+	private final AuthService authService;
+
+	@Operation(summary = "회원가입 요청", description = "회원가입을 하는 API", responses = {
+		@ApiResponse(responseCode = "200", description = "회원가입 성공"),
+		@ApiResponse(responseCode = "400", description = "잘못된 요청"),
+		@ApiResponse(responseCode = "500", description = "내부 서버 오류")
+	})
+	@PostMapping("/sign-up")
+	public void register(@Valid @RequestBody SignUpRequest request) {
+		authService.signUp(request.email(), request.password());
+	}
+
+	@Operation(summary = "로그인 요청", description = "로그인을 하는 API", responses = {
+		@ApiResponse(responseCode = "200", description = "로그인 성공"),
+		@ApiResponse(responseCode = "401", description = "인증 실패"),
+		@ApiResponse(responseCode = "500", description = "내부 서버 오류")
+	})
+	@PostMapping("/sign-in")
+	public void login(@Valid @RequestBody SignInRequest request) {
+		authService.signIn(request.email(), request.password());
+	}
+
+	@Operation(summary = "현재 사용자 정보", description = "현재 로그인한 사용자의 정보를 가져오는 API", responses = {
+		@ApiResponse(responseCode = "200", description = "현재 사용자 정보 조회 성공"),
+		@ApiResponse(responseCode = "401", description = "인증 실패"),
+		@ApiResponse(responseCode = "500", description = "내부 서버 오류")
+	})
+	@GetMapping("/me")
+	public String getCurrentUser(@LoginUser User user) {
+		return user.getEmail();
+	}
+}

--- a/src/main/java/mju/iphak/maru_egg/auth/application/AuthService.java
+++ b/src/main/java/mju/iphak/maru_egg/auth/application/AuthService.java
@@ -1,0 +1,42 @@
+package mju.iphak.maru_egg.auth.application;
+
+import static mju.iphak.maru_egg.common.exception.ErrorCode.*;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import mju.iphak.maru_egg.user.domain.User;
+import mju.iphak.maru_egg.user.repository.UserRepository;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+public class AuthService {
+
+	private final UserRepository userRepository;
+	private final PasswordEncoder passwordEncoder;
+
+	public void signUp(String email, String password) {
+		if (userRepository.findByEmail(email).isPresent()) {
+			throw new IllegalArgumentException("[Error] 이미 존재하는 이메일입니다.");
+		}
+		User user = User.of(email, password);
+		user.passwordEncode(passwordEncoder);
+		userRepository.save(user);
+		log.info("회원 저장 성공");
+	}
+
+	public void signIn(String email, String password) {
+		User user = userRepository.findByEmail(email)
+			.orElseThrow(() -> new EntityNotFoundException(
+				String.format(NOT_FOUND_USER.getMessage(), email)));
+		if (!passwordEncoder.matches(password, user.getPassword())) {
+			throw new IllegalArgumentException("[Error] 로그인에 실패했습니다.");
+		}
+	}
+}

--- a/src/main/java/mju/iphak/maru_egg/auth/dto/request/SignInRequest.java
+++ b/src/main/java/mju/iphak/maru_egg/auth/dto/request/SignInRequest.java
@@ -1,0 +1,15 @@
+package mju.iphak.maru_egg.auth.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotEmpty;
+
+public record SignInRequest(
+
+	@Email
+	@NotEmpty
+	String email,
+
+	@NotEmpty
+	String password
+) {
+}

--- a/src/main/java/mju/iphak/maru_egg/auth/dto/request/SignUpRequest.java
+++ b/src/main/java/mju/iphak/maru_egg/auth/dto/request/SignUpRequest.java
@@ -1,0 +1,22 @@
+package mju.iphak.maru_egg.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "회원가입 요청 DTO")
+public record SignUpRequest(
+
+	@Schema(description = "이메일")
+	@Email(message = "이메일 형식을 지켜주세요.")
+	@NotBlank(message = "email은 비어있을 수 없습니다.")
+	String email,
+
+	@Schema(description = "비밀번호")
+	@Size(min = 8, max = 20, message = "비밀번호는 8자에서 20자 사이여야합니다.")
+	@Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[@#$%^&+=!]).+$", message = "비밀번호는 문자, 숫자, 기호가 1개 이상 포함되어야합니다.")
+	String password
+) {
+}

--- a/src/main/java/mju/iphak/maru_egg/auth/dto/response/SignInResponse.java
+++ b/src/main/java/mju/iphak/maru_egg/auth/dto/response/SignInResponse.java
@@ -1,0 +1,18 @@
+package mju.iphak.maru_egg.auth.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Schema(description = "로그인 응답 DTO")
+@Builder
+public record SignInResponse(
+	@Schema(description = "acessToken")
+	String accessToken
+) {
+
+	public static SignInResponse from(String accessToken) {
+		return SignInResponse.builder()
+			.accessToken(accessToken)
+			.build();
+	}
+}

--- a/src/main/java/mju/iphak/maru_egg/auth/jwt/filter/JwtAuthenticationProcessingFilter.java
+++ b/src/main/java/mju/iphak/maru_egg/auth/jwt/filter/JwtAuthenticationProcessingFilter.java
@@ -1,0 +1,95 @@
+package mju.iphak.maru_egg.auth.jwt.filter;
+
+import java.io.IOException;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
+import org.springframework.security.core.authority.mapping.NullAuthoritiesMapper;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import mju.iphak.maru_egg.auth.CustomUserDetails;
+import mju.iphak.maru_egg.auth.jwt.service.JwtService;
+import mju.iphak.maru_egg.auth.jwt.util.PasswordUtil;
+import mju.iphak.maru_egg.user.domain.User;
+import mju.iphak.maru_egg.user.repository.UserRepository;
+
+@RequiredArgsConstructor
+@Slf4j
+public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
+	private static final String NO_CHECK_URL_LOGIN = "/api/auth/sign-in";
+	private static final String NO_CHECK_URL_HOME = "/api";
+
+	private final JwtService jwtService;
+	private final UserRepository userRepository;
+	private final GrantedAuthoritiesMapper authoritiesMapper = new NullAuthoritiesMapper();
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+		throws ServletException, IOException {
+		if (request.getRequestURI().equals(NO_CHECK_URL_LOGIN) || request.getRequestURI().equals(NO_CHECK_URL_HOME)) {
+			filterChain.doFilter(request, response);
+			return;
+		}
+
+		String refreshToken = jwtService.extractRefreshToken(request)
+			.filter(jwtService::isTokenValid)
+			.orElse(null);
+
+		if (refreshToken != null) {
+			checkRefreshTokenAndReIssueAccessToken(response, refreshToken);
+			return;
+		}
+
+		checkAccessTokenAndAuthentication(request, response, filterChain);
+	}
+
+	private void checkRefreshTokenAndReIssueAccessToken(HttpServletResponse response, String refreshToken) {
+		userRepository.findByRefreshToken(refreshToken)
+			.ifPresent(user -> {
+				String reIssuedRefreshToken = reIssueRefreshToken(user);
+				jwtService.sendAccessAndRefreshToken(response, jwtService.createAccessToken(user.getEmail()),
+					reIssuedRefreshToken);
+			});
+	}
+
+	private String reIssueRefreshToken(User user) {
+		String reIssuedRefreshToken = jwtService.createRefreshToken();
+		user.updateRefreshToken(reIssuedRefreshToken);
+		userRepository.saveAndFlush(user);
+		return reIssuedRefreshToken;
+	}
+
+	private void checkAccessTokenAndAuthentication(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain)
+		throws ServletException, IOException {
+		jwtService.extractAccessToken(request)
+			.filter(jwtService::isTokenValid)
+			.ifPresent(accessToken -> jwtService.extractEmail(accessToken)
+				.ifPresent(email -> userRepository.findByEmail(email)
+					.ifPresent(this::saveAuthentication)));
+
+		filterChain.doFilter(request, response);
+	}
+
+	private void saveAuthentication(User myUser) {
+		String password = myUser.getPassword();
+		if (password == null) {
+			password = PasswordUtil.generateRandomPassword();
+		}
+
+		CustomUserDetails userDetailsUser = new CustomUserDetails(myUser);
+
+		Authentication authentication = new UsernamePasswordAuthenticationToken(userDetailsUser, null,
+			authoritiesMapper.mapAuthorities(userDetailsUser.getAuthorities()));
+
+		SecurityContextHolder.getContext().setAuthentication(authentication);
+	}
+}

--- a/src/main/java/mju/iphak/maru_egg/auth/jwt/service/JwtService.java
+++ b/src/main/java/mju/iphak/maru_egg/auth/jwt/service/JwtService.java
@@ -1,0 +1,123 @@
+package mju.iphak.maru_egg.auth.jwt.service;
+
+import java.util.Date;
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import mju.iphak.maru_egg.user.repository.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+@Getter
+@Slf4j
+public class JwtService {
+
+	@Value("${jwt.secretKey}")
+	private String secretKey;
+
+	@Value("${jwt.access.expiration}")
+	private Long accessTokenExpirationPeriod;
+
+	@Value("${jwt.refresh.expiration}")
+	private Long refreshTokenExpirationPeriod;
+
+	@Value("${jwt.access.header}")
+	private String accessHeader;
+
+	@Value("${jwt.refresh.header}")
+	private String refreshHeader;
+
+	private static final String ACCESS_TOKEN_SUBJECT = "AccessToken";
+	private static final String REFRESH_TOKEN_SUBJECT = "RefreshToken";
+	private static final String EMAIL_CLAIM = "email";
+	private static final String BEARER = "Bearer ";
+
+	private final UserRepository userRepository;
+
+	public String createAccessToken(String email) {
+		Date now = new Date();
+		return JWT.create()
+			.withSubject(ACCESS_TOKEN_SUBJECT)
+			.withExpiresAt(new Date(now.getTime() + accessTokenExpirationPeriod))
+			.withClaim(EMAIL_CLAIM, email)
+			.sign(Algorithm.HMAC512(secretKey));
+	}
+
+	public String createRefreshToken() {
+		Date now = new Date();
+		return JWT.create()
+			.withSubject(REFRESH_TOKEN_SUBJECT)
+			.withExpiresAt(new Date(now.getTime() + refreshTokenExpirationPeriod))
+			.sign(Algorithm.HMAC512(secretKey));
+	}
+
+	public void sendAccessToken(HttpServletResponse response, String accessToken) {
+		response.setStatus(HttpServletResponse.SC_OK);
+		response.setHeader(accessHeader, accessToken);
+	}
+
+	public void sendAccessAndRefreshToken(HttpServletResponse response, String accessToken, String refreshToken) {
+		response.setStatus(HttpServletResponse.SC_OK);
+		setAccessTokenHeader(response, BEARER + accessToken);
+		setRefreshTokenHeader(response, BEARER + refreshToken);
+	}
+
+	public Optional<String> extractRefreshToken(HttpServletRequest request) {
+		return Optional.ofNullable(request.getHeader(refreshHeader))
+			.filter(refreshToken -> refreshToken.startsWith(BEARER))
+			.map(refreshToken -> refreshToken.replace(BEARER, ""));
+	}
+
+	public Optional<String> extractAccessToken(HttpServletRequest request) {
+		return Optional.ofNullable(request.getHeader(accessHeader))
+			.filter(refreshToken -> refreshToken.startsWith(BEARER))
+			.map(refreshToken -> refreshToken.replace(BEARER, ""));
+	}
+
+	public Optional<String> extractEmail(String accessToken) {
+		try {
+			return Optional.ofNullable(JWT.require(Algorithm.HMAC512(secretKey))
+				.build()
+				.verify(accessToken)
+				.getClaim(EMAIL_CLAIM)
+				.asString());
+		} catch (Exception e) {
+			return Optional.empty();
+		}
+	}
+
+	public void setAccessTokenHeader(HttpServletResponse response, String accessToken) {
+		response.setHeader(accessHeader, accessToken);
+	}
+
+	public void setRefreshTokenHeader(HttpServletResponse response, String refreshToken) {
+		response.setHeader(refreshHeader, refreshToken);
+	}
+
+	public void updateRefreshToken(String email, String refreshToken) {
+		userRepository.findByEmail(email)
+			.ifPresent(user -> {
+				user.updateRefreshToken(refreshToken);
+				userRepository.saveAndFlush(user);
+			});
+	}
+
+	public boolean isTokenValid(String token) {
+		try {
+			JWT.require(Algorithm.HMAC512(secretKey)).build().verify(token);
+			return true;
+		} catch (Exception e) {
+			return false;
+		}
+	}
+}

--- a/src/main/java/mju/iphak/maru_egg/auth/jwt/util/PasswordUtil.java
+++ b/src/main/java/mju/iphak/maru_egg/auth/jwt/util/PasswordUtil.java
@@ -1,0 +1,27 @@
+package mju.iphak.maru_egg.auth.jwt.util;
+
+import java.util.Random;
+
+public class PasswordUtil {
+	public static String generateRandomPassword() {
+		int index = 0;
+		char[] charSet = new char[] {
+			'0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+			'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
+			'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+			'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
+			'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z'
+		};
+
+		StringBuilder password = new StringBuilder();
+		Random random = new Random();
+
+		for (int i = 0; i < 8; i++) {
+			double rd = random.nextDouble();
+			index = (int)(charSet.length * rd);
+
+			password.append(charSet[index]);
+		}
+		return password.toString();
+	}
+}

--- a/src/main/java/mju/iphak/maru_egg/auth/login/filter/CustomJsonUsernamePasswordAuthenticationFilter.java
+++ b/src/main/java/mju/iphak/maru_egg/auth/login/filter/CustomJsonUsernamePasswordAuthenticationFilter.java
@@ -1,0 +1,59 @@
+package mju.iphak.maru_egg.auth.login.filter;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import org.springframework.security.authentication.AuthenticationServiceException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.util.StreamUtils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class CustomJsonUsernamePasswordAuthenticationFilter extends AbstractAuthenticationProcessingFilter {
+	private static final String DEFAULT_LOGIN_REQUEST_URL = "/api/auth/sign-in";
+	private static final String HTTP_METHOD = "POST";
+	private static final String CONTENT_TYPE = "application/json";
+	private static final String USERNAME_KEY = "email";
+	private static final String PASSWORD_KEY = "password";
+	private static final AntPathRequestMatcher DEFAULT_LOGIN_PATH_REQUEST_MATCHER =
+		new AntPathRequestMatcher(DEFAULT_LOGIN_REQUEST_URL, HTTP_METHOD);
+
+	private final ObjectMapper objectMapper;
+
+	public CustomJsonUsernamePasswordAuthenticationFilter(ObjectMapper objectMapper) {
+		super(DEFAULT_LOGIN_PATH_REQUEST_MATCHER);
+		this.objectMapper = objectMapper;
+	}
+
+	// UsernamePasswordAuthenticationToken 반환
+	@Override
+	public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws
+		AuthenticationException,
+		IOException {
+		if (request.getContentType() == null || !request.getContentType().equals(CONTENT_TYPE)) {
+			logger.error("Authentication Content-Type 을 application/json으로 변경해주세요.");
+			throw new AuthenticationServiceException(
+				"Authentication Content-Type not supported: " + request.getContentType());
+		}
+
+		String messageBody = StreamUtils.copyToString(request.getInputStream(), StandardCharsets.UTF_8);
+		Map<String, String> usernamePasswordMap = objectMapper.readValue(messageBody, Map.class);
+
+		String email = usernamePasswordMap.get(USERNAME_KEY);
+		String password = usernamePasswordMap.get(PASSWORD_KEY);
+
+		UsernamePasswordAuthenticationToken authRequest = new UsernamePasswordAuthenticationToken(email, password);
+
+		return this.getAuthenticationManager().authenticate(authRequest);
+	}
+}

--- a/src/main/java/mju/iphak/maru_egg/auth/login/handler/LoginFailureHandler.java
+++ b/src/main/java/mju/iphak/maru_egg/auth/login/handler/LoginFailureHandler.java
@@ -1,0 +1,24 @@
+package mju.iphak.maru_egg.auth.login.handler;
+
+import java.io.IOException;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class LoginFailureHandler extends SimpleUrlAuthenticationFailureHandler {
+
+	@Override
+	public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+		AuthenticationException exception) throws IOException {
+		response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+		response.setCharacterEncoding("UTF-8");
+		response.setContentType("text/plain;charset=UTF-8");
+		response.getWriter().write("로그인 실패! 이메일이나 비밀번호를 확인해주세요.");
+		log.info("로그인에 실패했습니다. 메시지 : {}", exception.getMessage());
+	}
+}

--- a/src/main/java/mju/iphak/maru_egg/auth/login/handler/LoginSuccessHandler.java
+++ b/src/main/java/mju/iphak/maru_egg/auth/login/handler/LoginSuccessHandler.java
@@ -1,0 +1,42 @@
+package mju.iphak.maru_egg.auth.login.handler;
+
+import java.io.IOException;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import mju.iphak.maru_egg.auth.jwt.service.JwtService;
+import mju.iphak.maru_egg.user.repository.UserRepository;
+
+@Slf4j
+@RequiredArgsConstructor
+public class LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+	private final JwtService jwtService;
+	private final UserRepository userRepository;
+
+	@Override
+	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+		Authentication authentication) throws IOException {
+		String email = extractUsername(authentication);
+		String accessToken = jwtService.createAccessToken(email);
+		String refreshToken = jwtService.createRefreshToken();
+
+		jwtService.sendAccessAndRefreshToken(response, accessToken, refreshToken);
+
+		userRepository.findByEmail(email)
+			.ifPresent(user -> {
+				user.updateRefreshToken(refreshToken);
+				userRepository.saveAndFlush(user);
+			});
+	}
+
+	private String extractUsername(Authentication authentication) {
+		UserDetails userDetails = (UserDetails)authentication.getPrincipal();
+		return userDetails.getUsername();
+	}
+}

--- a/src/main/java/mju/iphak/maru_egg/auth/login/service/LoginService.java
+++ b/src/main/java/mju/iphak/maru_egg/auth/login/service/LoginService.java
@@ -1,0 +1,33 @@
+package mju.iphak.maru_egg.auth.login.service;
+
+import static mju.iphak.maru_egg.common.exception.ErrorCode.*;
+
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import mju.iphak.maru_egg.user.domain.User;
+import mju.iphak.maru_egg.user.repository.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+public class LoginService implements UserDetailsService {
+
+	private final UserRepository userRepository;
+
+	@Override
+	public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+		User user = userRepository.findByEmail(email)
+			.orElseThrow(() -> new EntityNotFoundException(
+				String.format(NOT_FOUND_USER.getMessage(), email)));
+
+		return org.springframework.security.core.userdetails.User.builder()
+			.username(user.getEmail())
+			.password(user.getPassword())
+			.roles(user.getRole().name())
+			.build();
+	}
+}

--- a/src/main/java/mju/iphak/maru_egg/common/config/CustomCorsFilter.java
+++ b/src/main/java/mju/iphak/maru_egg/common/config/CustomCorsFilter.java
@@ -16,7 +16,7 @@ import jakarta.servlet.http.HttpServletResponse;
 
 @Component
 @Order(Ordered.HIGHEST_PRECEDENCE)
-public class CorsFilter implements Filter {
+public class CustomCorsFilter implements Filter {
 
 	@Override
 	public void doFilter(final ServletRequest req, final ServletResponse res, final FilterChain chain) throws

--- a/src/main/java/mju/iphak/maru_egg/common/config/SecurityConfig.java
+++ b/src/main/java/mju/iphak/maru_egg/common/config/SecurityConfig.java
@@ -1,0 +1,132 @@
+package mju.iphak.maru_egg.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.HttpStatusEntryPoint;
+import org.springframework.security.web.authentication.logout.LogoutFilter;
+import org.springframework.security.web.servlet.util.matcher.MvcRequestMatcher;
+import org.springframework.web.servlet.handler.HandlerMappingIntrospector;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+import mju.iphak.maru_egg.auth.jwt.filter.JwtAuthenticationProcessingFilter;
+import mju.iphak.maru_egg.auth.jwt.service.JwtService;
+import mju.iphak.maru_egg.auth.login.filter.CustomJsonUsernamePasswordAuthenticationFilter;
+import mju.iphak.maru_egg.auth.login.handler.LoginFailureHandler;
+import mju.iphak.maru_egg.auth.login.handler.LoginSuccessHandler;
+import mju.iphak.maru_egg.auth.login.service.LoginService;
+import mju.iphak.maru_egg.user.repository.UserRepository;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+	private static final String API_PREFIX = "/api";
+
+	private final LoginService loginService;
+	private final JwtService jwtService;
+	private final UserRepository userRepository;
+	private final ObjectMapper objectMapper;
+
+	@Bean
+	public WebSecurityCustomizer webSecurityCustomizer() {
+		return (web) -> web.ignoring()
+			.requestMatchers("/favicon.ico", "/css/**", "/js/**", "/img/**", "/lib/**");
+	}
+
+	@Bean
+	public SecurityFilterChain filterChain(HttpSecurity http, HandlerMappingIntrospector introspector) throws
+		Exception {
+		http
+			.csrf(AbstractHttpConfigurer::disable)
+			.formLogin(AbstractHttpConfigurer::disable)
+			.httpBasic(AbstractHttpConfigurer::disable)
+			.sessionManagement(sessionManagement ->
+				sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+			.exceptionHandling(e -> e
+				.authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED)))
+			.authorizeHttpRequests(authorizeHttpRequests ->
+				authorizeHttpRequests
+					.requestMatchers(new MvcRequestMatcher(introspector, API_PREFIX + "/"))
+					.permitAll()
+					.requestMatchers(new MvcRequestMatcher(introspector, API_PREFIX + "/auth/sign-up"))
+					.permitAll()
+					.requestMatchers(new MvcRequestMatcher(introspector, API_PREFIX + "/auth/sign-in"))
+					.permitAll()
+					.requestMatchers(new MvcRequestMatcher(introspector, API_PREFIX + "/questions/**"))
+					.permitAll()
+					.requestMatchers(new MvcRequestMatcher(introspector, "/maru-egg/api-docs/**"))
+					.permitAll()
+					.requestMatchers(new MvcRequestMatcher(introspector, "/maru-egg/swagger-ui/index.html"))
+					.permitAll()
+					.requestMatchers(new MvcRequestMatcher(introspector, "/maru-egg/swagger-ui/**")) // Swagger UI 접근 허용
+					.permitAll()
+					.requestMatchers(new MvcRequestMatcher(introspector, "/v3/api-docs/**")) // Swagger API docs 접근 허용
+					.permitAll()
+					.requestMatchers(new MvcRequestMatcher(introspector, API_PREFIX + "/admin/**"))
+					.hasRole("ADMIN")
+					.anyRequest()
+					.authenticated())
+
+			// AuthenticationFilter 커스텀 적용
+			.addFilterAfter(customJsonUsernamePasswordAuthenticationFilter(), LogoutFilter.class)
+
+			// JWT Filter 후 사용자 인증
+			.addFilterBefore(jwtAuthenticationProcessingFilter(), CustomJsonUsernamePasswordAuthenticationFilter.class);
+
+		return http.build();
+	}
+
+	@Bean
+	public PasswordEncoder passwordEncoder() {
+		return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+	}
+
+	// AuthenticationManager <-> AuthenticatorProvider <-> UserDetailsService <-> UserDetails
+	@Bean
+	public AuthenticationManager authenticationManager() {
+		DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
+		provider.setPasswordEncoder(passwordEncoder());
+		provider.setUserDetailsService(loginService);
+		return new ProviderManager(provider);
+	}
+
+	@Bean
+	public LoginSuccessHandler loginSuccessHandler() {
+		return new LoginSuccessHandler(jwtService, userRepository);
+	}
+
+	@Bean
+	public LoginFailureHandler loginFailureHandler() {
+		return new LoginFailureHandler();
+	}
+
+	@Bean
+	public CustomJsonUsernamePasswordAuthenticationFilter customJsonUsernamePasswordAuthenticationFilter() {
+		CustomJsonUsernamePasswordAuthenticationFilter customFilter =
+			new CustomJsonUsernamePasswordAuthenticationFilter(objectMapper);
+		customFilter.setAuthenticationManager(authenticationManager());
+		customFilter.setAuthenticationSuccessHandler(loginSuccessHandler());
+		customFilter.setAuthenticationFailureHandler(loginFailureHandler());
+		return customFilter;
+	}
+
+	@Bean
+	public JwtAuthenticationProcessingFilter jwtAuthenticationProcessingFilter() {
+		return new JwtAuthenticationProcessingFilter(jwtService, userRepository);
+	}
+}

--- a/src/main/java/mju/iphak/maru_egg/common/config/SwaggerConfig.java
+++ b/src/main/java/mju/iphak/maru_egg/common/config/SwaggerConfig.java
@@ -15,6 +15,10 @@ import io.swagger.v3.oas.models.media.MediaType;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.oas.models.responses.ApiResponses;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.security.SecurityScheme.In;
+import io.swagger.v3.oas.models.security.SecurityScheme.Type;
 import mju.iphak.maru_egg.common.exception.ErrorResponse;
 
 @Configuration
@@ -23,8 +27,16 @@ public class SwaggerConfig {
 	@Bean
 	public OpenAPI openAPI() {
 		return new OpenAPI()
-			.components(new Components().addSchemas("ErrorResponse", createErrorResponseSchema()))
-			.info(apiInfo());
+			.components(new Components()
+				.addSecuritySchemes("bearerAuth", new SecurityScheme()
+					.type(Type.HTTP)
+					.scheme("bearer")
+					.bearerFormat("JWT")
+					.in(In.HEADER)
+					.name("Authorization"))
+				.addSchemas("ErrorResponse", createErrorResponseSchema()))
+			.info(apiInfo())
+			.addSecurityItem(new SecurityRequirement().addList("bearerAuth"));
 	}
 
 	private Info apiInfo() {

--- a/src/main/java/mju/iphak/maru_egg/common/config/WebConfig.java
+++ b/src/main/java/mju/iphak/maru_egg/common/config/WebConfig.java
@@ -7,10 +7,12 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
 
+	private static final String ORIGIN_URL = "http://localhost:3000";
+
 	@Override
 	public void addCorsMappings(CorsRegistry registry) {
 		registry.addMapping("/**")
-			.allowedOrigins("http://localhost:3000")
+			.allowedOrigins(ORIGIN_URL)
 			.allowedMethods("GET", "POST", "PUT", "DELETE")
 			.allowedHeaders("Authorization", "Content-Type")
 			.exposedHeaders("Custom-Header")

--- a/src/main/java/mju/iphak/maru_egg/common/exception/ErrorCode.java
+++ b/src/main/java/mju/iphak/maru_egg/common/exception/ErrorCode.java
@@ -17,7 +17,9 @@ public enum ErrorCode {
 	NOT_FOUND_QUESTION(NOT_FOUND, "type: %s, category: %s, content: %s인 질문을 찾을 수 없습니다."),
 	NOT_FOUND_QUESTION_BY_ID(NOT_FOUND, "id: %s인 질문을 찾을 수 없습니다."),
 	NOT_FOUND_QUESTION_WITHOUT_CATEGORY(NOT_FOUND, "type: %s, content: %s인 질문을 찾을 수 없습니다."),
+	NOT_FOUND_QUESTION_BY_TYPE_CATEGORY(NOT_FOUND, "type: %s, category: %s인 질문을 찾을 수 없습니다."),
 	NOT_FOUND_ANSWER(NOT_FOUND, "질문 id가 %s인 답변을 찾을 수 없습니다."),
+	NOT_FOUND_USER(NOT_FOUND, "유저 이메일이 %s인 유저를 찾을 수 없습니다."),
 
 	// 500 error
 	INTERNAL_ERROR_SIMILARITY(NOT_FOUND, "contentToken: %s, question: %s인 질문의 유사도를 검사하는 도중 오류가 발생했습니다.");

--- a/src/main/java/mju/iphak/maru_egg/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/mju/iphak/maru_egg/common/exception/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import java.time.format.DateTimeFormatter;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -52,6 +53,14 @@ public class GlobalExceptionHandler {
 		String errorMessage = "Invalid input format: " + e.getLocalizedMessage();
 		return ResponseEntity.status(BAD_REQUEST)
 			.body(ErrorResponse.of(e.getClass().getSimpleName(), BAD_REQUEST.value(), errorMessage));
+	}
+
+	@ExceptionHandler(UsernameNotFoundException.class)
+	protected ResponseEntity<ErrorResponse> handleUsernameNotFoundException(UsernameNotFoundException e) {
+		String timestamp = getCurrentTimestamp();
+		log.error(LOG_FORMAT, timestamp, e.getClass().getSimpleName(), e.getMessage());
+		return ResponseEntity.status(NOT_FOUND)
+			.body(ErrorResponse.of(e.getClass().getSimpleName(), NOT_FOUND.value(), e.getMessage()));
 	}
 
 	private String getCurrentTimestamp() {

--- a/src/main/java/mju/iphak/maru_egg/question/api/QuestionController.java
+++ b/src/main/java/mju/iphak/maru_egg/question/api/QuestionController.java
@@ -1,5 +1,9 @@
 package mju.iphak.maru_egg.question.api;
 
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -11,6 +15,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import mju.iphak.maru_egg.question.application.QuestionService;
+import mju.iphak.maru_egg.question.dto.request.FindQuestionsRequest;
 import mju.iphak.maru_egg.question.dto.request.QuestionRequest;
 import mju.iphak.maru_egg.question.dto.response.QuestionResponse;
 
@@ -30,5 +35,15 @@ public class QuestionController {
 	@PostMapping()
 	public QuestionResponse question(@Valid @RequestBody QuestionRequest request) {
 		return questionService.question(request.type(), request.category(), request.content());
+	}
+
+	@Operation(summary = "질문 목록 요청", description = "질문 목록을 보내주는 API", responses = {
+		@ApiResponse(responseCode = "200", description = "질문 성공"),
+		@ApiResponse(responseCode = "404", description = "질문 또는 답변을 찾지 못한 경우"),
+		@ApiResponse(responseCode = "500", description = "내부 서버 오류")
+	})
+	@GetMapping()
+	public List<QuestionResponse> getQuestions(@Valid @ModelAttribute FindQuestionsRequest request) {
+		return questionService.getQuestions(request.type(), request.category());
 	}
 }

--- a/src/main/java/mju/iphak/maru_egg/question/domain/QuestionCategory.java
+++ b/src/main/java/mju/iphak/maru_egg/question/domain/QuestionCategory.java
@@ -1,8 +1,10 @@
 package mju.iphak.maru_egg.question.domain;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+@Schema(description = "질문 카테고리", enumAsRef = true)
 @Getter
 @RequiredArgsConstructor
 public enum QuestionCategory {

--- a/src/main/java/mju/iphak/maru_egg/question/domain/QuestionType.java
+++ b/src/main/java/mju/iphak/maru_egg/question/domain/QuestionType.java
@@ -1,7 +1,9 @@
 package mju.iphak.maru_egg.question.domain;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.RequiredArgsConstructor;
 
+@Schema(description = "질문 타입", enumAsRef = true)
 @RequiredArgsConstructor
 public enum QuestionType {
 	SUSI("수시"),

--- a/src/main/java/mju/iphak/maru_egg/question/dto/request/FindQuestionsRequest.java
+++ b/src/main/java/mju/iphak/maru_egg/question/dto/request/FindQuestionsRequest.java
@@ -1,0 +1,22 @@
+package mju.iphak.maru_egg.question.dto.request;
+
+import org.springdoc.core.annotations.ParameterObject;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import mju.iphak.maru_egg.question.domain.QuestionCategory;
+import mju.iphak.maru_egg.question.domain.QuestionType;
+
+@Schema(description = "질문 목록 요청 DTO")
+@ParameterObject
+public record FindQuestionsRequest(
+
+	@Schema(description = "질문 타입(수시, 정시, 편입학, 재외국민)", allowableValues = {"SUSI", "JEONGSI", "PYEONIP", "JEAOEGUGMIN"})
+	@NotNull(message = "질문 타입은 비어있을 수 없습니다.")
+	QuestionType type,
+
+	@Schema(description = "질문 카테고리(모집요강, 입시결과, 기출 문제)", allowableValues = {"ADMISSION_GUIDELINE", "PASSING_RESULT",
+		"PAST_QUESTIONS", "ETC", "UNIV_LIFE", "INTERVIEW_PRACTICAL_TEST"})
+	QuestionCategory category
+) {
+}

--- a/src/main/java/mju/iphak/maru_egg/question/dto/response/QuestionCore.java
+++ b/src/main/java/mju/iphak/maru_egg/question/dto/response/QuestionCore.java
@@ -3,12 +3,12 @@ package mju.iphak.maru_egg.question.dto.response;
 import lombok.Builder;
 
 @Builder
-public record QuestionCoreDTO(
+public record QuestionCore(
 	Long id,
 	String contentToken
 ) {
-	public static QuestionCoreDTO of(Long id, String contentToken) {
-		return QuestionCoreDTO.builder()
+	public static QuestionCore of(Long id, String contentToken) {
+		return QuestionCore.builder()
 			.id(id)
 			.contentToken(contentToken)
 			.build();

--- a/src/main/java/mju/iphak/maru_egg/question/dto/response/QuestionResponse.java
+++ b/src/main/java/mju/iphak/maru_egg/question/dto/response/QuestionResponse.java
@@ -9,6 +9,7 @@ import mju.iphak.maru_egg.question.domain.Question;
 @Schema(description = "질문 응답 DTO", example = """
 	{
 	  "id": 600697396846981500,
+	  "content": "수시 일정 알려주세요."
 	  "dateInformation": "생성일자: 2024-07-15T23:36:59.834804, 마지막 DB 갱신일자: 2024-07-15T23:36:59.834804",
 	  "answer": {
 	    "id": 600697396935061600,
@@ -22,6 +23,9 @@ public record QuestionResponse(
 	@Schema(description = "질문 id")
 	Long id,
 
+	@Schema(description = "질문")
+	String content,
+
 	@Schema(description = "답변 DB 생성 및 업데이트 날짜")
 	String dateInformation,
 
@@ -32,6 +36,7 @@ public record QuestionResponse(
 	public static QuestionResponse of(Question question, AnswerResponse answer) {
 		return QuestionResponse.builder()
 			.id(question.getId())
+			.content(question.getContent())
 			.dateInformation(question.getDateInformation())
 			.answer(answer)
 			.build();

--- a/src/main/java/mju/iphak/maru_egg/question/meta/LoginUser.java
+++ b/src/main/java/mju/iphak/maru_egg/question/meta/LoginUser.java
@@ -1,0 +1,14 @@
+package mju.iphak.maru_egg.question.meta;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+@AuthenticationPrincipal(expression = "#this == 'anonymousUser' ? null : user")
+public @interface LoginUser {
+}

--- a/src/main/java/mju/iphak/maru_egg/question/repository/QuestionRepository.java
+++ b/src/main/java/mju/iphak/maru_egg/question/repository/QuestionRepository.java
@@ -1,6 +1,6 @@
 package mju.iphak.maru_egg.question.repository;
 
-import java.util.Optional;
+import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -9,8 +9,5 @@ import mju.iphak.maru_egg.question.domain.QuestionCategory;
 import mju.iphak.maru_egg.question.domain.QuestionType;
 
 public interface QuestionRepository extends JpaRepository<Question, Long>, QuestionRepositoryCustom {
-	Optional<Question> findByQuestionTypeAndQuestionCategoryAndContent(
-		final QuestionType questionType,
-		final QuestionCategory questionCategory,
-		final String content);
+	List<Question> findAllByQuestionTypeAndQuestionCategory(QuestionType type, QuestionCategory category);
 }

--- a/src/main/java/mju/iphak/maru_egg/question/repository/QuestionRepositoryCustom.java
+++ b/src/main/java/mju/iphak/maru_egg/question/repository/QuestionRepositoryCustom.java
@@ -5,12 +5,12 @@ import java.util.Optional;
 
 import mju.iphak.maru_egg.question.domain.QuestionCategory;
 import mju.iphak.maru_egg.question.domain.QuestionType;
-import mju.iphak.maru_egg.question.dto.response.QuestionCoreDTO;
+import mju.iphak.maru_egg.question.dto.response.QuestionCore;
 
 public interface QuestionRepositoryCustom {
-	Optional<List<QuestionCoreDTO>> searchQuestionsByContentTokenAndType(String contentToken, QuestionType type);
+	Optional<List<QuestionCore>> searchQuestionsByContentTokenAndType(String contentToken, QuestionType type);
 
-	Optional<List<QuestionCoreDTO>> searchQuestionsByContentTokenAndTypeAndCategory(String contentToken,
+	Optional<List<QuestionCore>> searchQuestionsByContentTokenAndTypeAndCategory(String contentToken,
 		QuestionType type,
 		QuestionCategory category);
 }

--- a/src/main/java/mju/iphak/maru_egg/question/repository/QuestionRepositoryImpl.java
+++ b/src/main/java/mju/iphak/maru_egg/question/repository/QuestionRepositoryImpl.java
@@ -18,7 +18,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import mju.iphak.maru_egg.question.domain.QuestionCategory;
 import mju.iphak.maru_egg.question.domain.QuestionType;
-import mju.iphak.maru_egg.question.dto.response.QuestionCoreDTO;
+import mju.iphak.maru_egg.question.dto.response.QuestionCore;
 
 @Repository
 @RequiredArgsConstructor
@@ -27,7 +27,7 @@ public class QuestionRepositoryImpl implements QuestionRepositoryCustom {
 	private final JPAQueryFactory queryFactory;
 
 	@Override
-	public Optional<List<QuestionCoreDTO>> searchQuestionsByContentTokenAndType(final String contentToken,
+	public Optional<List<QuestionCore>> searchQuestionsByContentTokenAndType(final String contentToken,
 		final QuestionType type) {
 		BooleanTemplate matchExpression = booleanTemplate("function('match_against', {0}, {1}) > 0", question.content,
 			contentToken);
@@ -37,15 +37,15 @@ public class QuestionRepositoryImpl implements QuestionRepositoryCustom {
 			.where(matchExpression.and(question.questionType.eq(type)))
 			.fetch();
 
-		List<QuestionCoreDTO> result = tuples.stream()
-			.map(tuple -> QuestionCoreDTO.of(tuple.get(question.id), tuple.get(question.contentToken)))
+		List<QuestionCore> result = tuples.stream()
+			.map(tuple -> QuestionCore.of(tuple.get(question.id), tuple.get(question.contentToken)))
 			.collect(Collectors.toList());
 
 		return Optional.of(result);
 	}
 
 	@Override
-	public Optional<List<QuestionCoreDTO>> searchQuestionsByContentTokenAndTypeAndCategory(final String contentToken,
+	public Optional<List<QuestionCore>> searchQuestionsByContentTokenAndTypeAndCategory(final String contentToken,
 		final QuestionType type, final QuestionCategory category) {
 		NumberTemplate<Double> booleanTemplate = Expressions.numberTemplate(Double.class, "function('match', {0}, {1})",
 			question.content,
@@ -57,8 +57,8 @@ public class QuestionRepositoryImpl implements QuestionRepositoryCustom {
 				booleanTemplate.gt(0))
 			.fetch();
 
-		List<QuestionCoreDTO> result = tuples.stream()
-			.map(tuple -> QuestionCoreDTO.of(tuple.get(question.id), tuple.get(question.contentToken)))
+		List<QuestionCore> result = tuples.stream()
+			.map(tuple -> QuestionCore.of(tuple.get(question.id), tuple.get(question.contentToken)))
 			.collect(Collectors.toList());
 		return Optional.of(result);
 	}

--- a/src/main/java/mju/iphak/maru_egg/user/domain/Role.java
+++ b/src/main/java/mju/iphak/maru_egg/user/domain/Role.java
@@ -8,4 +8,8 @@ public enum Role {
 	ADMIN("ROLE_ADMIN");
 
 	private final String role;
+
+	public String getRoleName() {
+		return role;
+	}
 }

--- a/src/main/java/mju/iphak/maru_egg/user/domain/User.java
+++ b/src/main/java/mju/iphak/maru_egg/user/domain/User.java
@@ -2,6 +2,8 @@ package mju.iphak.maru_egg.user.domain;
 
 import static mju.iphak.maru_egg.common.regex.UserRegex.*;
 
+import org.springframework.security.crypto.password.PasswordEncoder;
+
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -27,8 +29,26 @@ public class User extends BaseEntity {
 
 	private String password;
 
+	private String refreshToken;
+
 	@Enumerated(EnumType.STRING)
 	private Role role;
+
+	public void passwordEncode(PasswordEncoder passwordEncoder) {
+		this.password = passwordEncoder.encode(this.password);
+	}
+
+	public void updateRefreshToken(String updateRefreshToken) {
+		this.refreshToken = updateRefreshToken;
+	}
+
+	public static User of(String email, String password) {
+		return User.builder()
+			.email(email)
+			.password(password)
+			.role(Role.ADMIN)
+			.build();
+	}
 }
 
 

--- a/src/main/java/mju/iphak/maru_egg/user/repository/UserRepository.java
+++ b/src/main/java/mju/iphak/maru_egg/user/repository/UserRepository.java
@@ -8,4 +8,6 @@ import mju.iphak.maru_egg.user.domain.User;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 	Optional<User> findByEmail(String email);
+
+	Optional<User> findByRefreshToken(String refreshToken);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,18 @@ spring:
 web-client:
   base-url: ${LLM_BASE_URL}
 
+
+jwt:
+  secretKey: ${JWT_SECRET}
+
+  access:
+    expiration: 3600000 # 1시간(60분) (1000L(ms -> s) * 60L(s -> m) * 60L(m -> h))
+    header: "Authorization"
+
+  refresh:
+    expiration: 1209600000 #  (1000L(ms -> s) * 60L(s -> m) * 60L(m -> h) * 24L(h -> 하루) * 14(2주))
+    header: "Authorization-refresh"
+
 springdoc:
   api-docs:
     path: /maru-egg/api-docs

--- a/src/test/java/mju/iphak/maru_egg/question/application/QuestionServiceTest.java
+++ b/src/test/java/mju/iphak/maru_egg/question/application/QuestionServiceTest.java
@@ -37,7 +37,7 @@ import mju.iphak.maru_egg.common.MockTest;
 import mju.iphak.maru_egg.question.domain.Question;
 import mju.iphak.maru_egg.question.domain.QuestionCategory;
 import mju.iphak.maru_egg.question.domain.QuestionType;
-import mju.iphak.maru_egg.question.dto.response.QuestionCoreDTO;
+import mju.iphak.maru_egg.question.dto.response.QuestionCore;
 import mju.iphak.maru_egg.question.dto.response.QuestionResponse;
 import mju.iphak.maru_egg.question.repository.QuestionRepository;
 import mju.iphak.maru_egg.question.utils.PhraseExtractionUtils;
@@ -115,7 +115,7 @@ class QuestionServiceTest extends MockTest {
 		when(answerRepository.findByQuestionId(anyLong())).thenReturn(Optional.of(answer));
 		when(questionRepository.searchQuestionsByContentTokenAndTypeAndCategory(anyString(), any(QuestionType.class),
 			any(QuestionCategory.class)))
-			.thenReturn(Optional.of(List.of(QuestionCoreDTO.of(1L, "테스트 질문입니다."))));
+			.thenReturn(Optional.of(List.of(QuestionCore.of(1L, "테스트 질문입니다."))));
 		when(questionRepository.findById(1L)).thenReturn(Optional.of(question));
 		questionService = new QuestionService(questionRepository, answerService);
 
@@ -136,7 +136,7 @@ class QuestionServiceTest extends MockTest {
 		String contentToken = PhraseExtractionUtils.extractPhrases(content);
 
 		when(questionRepository.searchQuestionsByContentTokenAndTypeAndCategory(anyString(), eq(type), eq(category)))
-			.thenReturn(Optional.of(List.of(QuestionCoreDTO.of(1L, contentToken))));
+			.thenReturn(Optional.of(List.of(QuestionCore.of(1L, contentToken))));
 
 		// when
 		QuestionResponse result = questionService.question(type, category, content);


### PR DESCRIPTION
## ✅ 작업 내용
- Spring Security를 이용하여 JWT 방식의 로그인 및 회원가입을 구현했습니다.
- Security filter에서 아래와 같은 Bean을 의존합니다.

•	WebSecurityCustomizer: 특정 경로를 보안 필터 체인에서 제외하도록 설정.
•	SecurityFilterChain: 보안 필터 체인 설정.
•	PasswordEncoder: 비밀번호 암호화 빈.
•	AuthenticationManager: 사용자 인증 관리 빈.
•	LoginSuccessHandler, LoginFailureHandler: 로그인 성공 및 실패 처리 핸들러.
•	CustomJsonUsernamePasswordAuthenticationFilter: 사용자 정의 로그인 필터.
•	JwtAuthenticationProcessingFilter: JWT 인증 필터.

- 각 필터의 흐름은 다음과 같이 진행됩니다.
1. LogoutFilter

•	사용자 로그아웃을 처리합니다.

2. CustomJsonUsernamePasswordAuthenticationFilter

•	로그인 요청을 처리하고 인증을 시도합니다.
•	CustomJsonUsernamePasswordAuthenticationFilter는 JSON 형식의 로그인 요청을 처리합니다.
•	로그인 성공 시 LoginSuccessHandler를 호출하여 JWT 토큰을 생성하고 반환합니다.
•	로그인 실패 시 LoginFailureHandler를 호출합니다.

3. JwtAuthenticationProcessingFilter

•	각 요청에 대해 JWT 토큰을 검사합니다.
•	토큰이 유효하면 인증된 사용자를 SecurityContext에 설정합니다.

4. AuthenticationManager 및 관련 구성 요소

•	DaoAuthenticationProvider: 사용자 인증을 위한 DAO 제공자.
•	PasswordEncoder: 비밀번호 암호화.
•	UserDetailsService 인터페이스를 구현한 LoginService를 사용하여 사용자 정보를 로드하고 인증합니다.

- 주요 흐름을 요약하면
	1.	클라이언트가 로그인 요청을 CustomJsonUsernamePasswordAuthenticationFilter로 보냅니다.
	2.	필터가 로그인 데이터를 확인하고 인증을 시도합니다.
	3.	인증 성공 시 LoginSuccessHandler를 통해 JWT 토큰을 생성하고 반환합니다.
	4.	클라이언트는 JWT 토큰을 이후 요청의 Authorization 헤더에 포함하여 보냅니다.
	5.	JwtAuthenticationProcessingFilter는 각 요청에서 JWT 토큰을 검증하고 인증된 사용자를 SecurityContext에 설정합니다.
	6.	요청이 SecurityContext를 통해 인증된 사용자로 처리됩니다.

---

- QuestionResponse를 확장성 좋게 변경했습니다.
  - 이제는 질문에 대한 답변 응답 response 에 어떤 질문에 대한 답변인지 확인할 수 있습니다.
- 이로 인해 질문 목록 조회에 사용될 response를 List 형식의 QuestionResponse가 처리할 수 있게 됩니다.

## 🤔 고민 했던 부분
- 몇번 조회되었는지도 필요하면 반환하도록 처리할지 고민 됩니다. @swgvenghy 확인 부탁합니다
