### PR TITLE
[feat] 자동완성 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,9 +24,44 @@ repositories {
     mavenCentral()
 }
 
+
+// Jacoco 설정
 jacoco {
     toolVersion = "0.8.11"
     reportsDirectory = layout.buildDirectory.dir('customJacocoReportDir')
+}
+
+test {
+    finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+    dependsOn test
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
+    finalizedBy 'jacocoTestReport'
+}
+
+jacocoTestReport {
+    dependsOn test
+    afterEvaluate {
+        classDirectories.setFrom(files(classDirectories.files.collect {
+            fileTree(dir: it, exclude: [
+                    "mju/iphak/maru_egg/common/**",
+                    "mju/iphak/maru_egg/*Request*",
+                    "mju/iphak/maru_egg/*Command*",
+                    "mju/iphak/maru_egg/*Response*",
+                    "mju/iphak/maru_egg/*Mapper*"
+            ])
+        }))
+    }
+    reports {
+        html.enabled true
+        xml.enabled true
+        csv.enabled false
+    }
 }
 
 dependencies {
@@ -86,37 +121,4 @@ tasks.named('test') {
 
 jar {
     enabled = false
-}
-
-test {
-    finalizedBy jacocoTestReport
-}
-jacocoTestReport {
-    dependsOn test
-}
-
-
-jacocoTestReport {
-    reports {
-        xml.required = false
-        csv.required = false
-        html.outputLocation = layout.buildDirectory.dir('jacocoHtml')
-    }
-}
-
-// 테스트 커버리지 검사
-jacocoTestCoverageVerification {
-    violationRules {
-        rule {
-            element 'CLASS'
-            limit {
-                counter = 'BRANCH'
-                value = 'COVEREDRATIO'
-                minimum = 0.5
-            }
-
-            // 커버리지 체크를 제외할 클래스들
-            excludes = ['*.*Controller', '*.dto.*', '*.config.*', '*.domain.Q*']
-        }
-    }
 }

--- a/src/main/java/mju/iphak/maru_egg/common/config/SwaggerConfig.java
+++ b/src/main/java/mju/iphak/maru_egg/common/config/SwaggerConfig.java
@@ -1,6 +1,7 @@
 package mju.iphak.maru_egg.common.config;
 
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Map;
 
 import org.springdoc.core.customizers.OperationCustomizer;
@@ -70,7 +71,7 @@ public class SwaggerConfig {
 				ApiResponse apiResponse = new ApiResponse();
 				apiResponse.setDescription(customApiResponse.description());
 				addContent(apiResponse, customApiResponse.error(), customApiResponse.status(),
-					customApiResponse.message());
+					customApiResponse.message(), customApiResponse.isArray());
 				apiResponses.addApiResponse(String.valueOf(customApiResponse.status()), apiResponse);
 			}
 		} else {
@@ -79,19 +80,27 @@ public class SwaggerConfig {
 				ApiResponse apiResponse = new ApiResponse();
 				apiResponse.setDescription(customApiResponse.description());
 				addContent(apiResponse, customApiResponse.error(), customApiResponse.status(),
-					customApiResponse.message());
+					customApiResponse.message(), customApiResponse.isArray());
 				apiResponses.addApiResponse(String.valueOf(customApiResponse.status()), apiResponse);
 			}
 		}
 	}
 
-	private void addContent(ApiResponse apiResponse, String error, int status, String message) {
+	private void addContent(ApiResponse apiResponse, String error, int status, String message, boolean isArray) {
 		Content content = new Content();
 		MediaType mediaType = new MediaType();
-		Schema<ErrorResponse> schema = new Schema<>();
-		schema.$ref("#/components/schemas/ErrorResponse");
+		Schema<?> schema;
+		if (isArray) {
+			schema = new Schema<List<ErrorResponse>>()
+				.type("array")
+				.items(new Schema<ErrorResponse>().$ref("#/components/schemas/ErrorResponse"));
+		} else {
+			schema = new Schema<ErrorResponse>()
+				.$ref("#/components/schemas/ErrorResponse");
+		}
 		mediaType.schema(schema)
-			.example(new ErrorResponse(error, status, message));
+			.example(isArray ? List.of(new ErrorResponse(error, status, message)) :
+				new ErrorResponse(error, status, message));
 		content.addMediaType("application/json", mediaType);
 		apiResponse.setContent(content);
 	}

--- a/src/main/java/mju/iphak/maru_egg/common/dto/pagination/SliceQuestionResponse.java
+++ b/src/main/java/mju/iphak/maru_egg/common/dto/pagination/SliceQuestionResponse.java
@@ -1,0 +1,16 @@
+package mju.iphak.maru_egg.common.dto.pagination;
+
+import java.util.List;
+
+public record SliceQuestionResponse<T>(
+	List<T> data,
+	int currentPage,
+	int pageSize,
+	boolean hasNext,
+	Integer nextCursorViewCount,
+	Long nextQuestionId
+) {
+	public SliceQuestionResponse(List<T> data, int currentPage, int pageSize, boolean hasNext) {
+		this(data, currentPage, pageSize, hasNext, null, null);
+	}
+}

--- a/src/main/java/mju/iphak/maru_egg/common/meta/CustomApiResponse.java
+++ b/src/main/java/mju/iphak/maru_egg/common/meta/CustomApiResponse.java
@@ -19,4 +19,6 @@ public @interface CustomApiResponse {
 	String message() default "서버에 오류가 발생했습니다. 담당자에게 연락주세요.";
 
 	String description() default "내부 서버 오류";
+
+	boolean isArray() default false;
 }

--- a/src/main/java/mju/iphak/maru_egg/question/api/QuestionController.java
+++ b/src/main/java/mju/iphak/maru_egg/question/api/QuestionController.java
@@ -16,6 +16,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import mju.iphak.maru_egg.common.meta.CustomApiResponse;
 import mju.iphak.maru_egg.common.meta.CustomApiResponses;
+import mju.iphak.maru_egg.question.application.QuestionProcessingService;
 import mju.iphak.maru_egg.question.application.QuestionService;
 import mju.iphak.maru_egg.question.dto.request.FindQuestionsRequest;
 import mju.iphak.maru_egg.question.dto.request.QuestionRequest;
@@ -27,6 +28,7 @@ import mju.iphak.maru_egg.question.dto.response.QuestionResponse;
 @RequestMapping("/api/questions")
 public class QuestionController {
 
+	private final QuestionProcessingService questionProcessingService;
 	private final QuestionService questionService;
 
 	@Operation(summary = "질문 요청", description = "질문하는 API", responses = {
@@ -39,7 +41,7 @@ public class QuestionController {
 	})
 	@PostMapping()
 	public QuestionResponse question(@Valid @RequestBody QuestionRequest request) {
-		return questionService.question(request.type(), request.category(), request.content());
+		return questionProcessingService.question(request.type(), request.category(), request.content());
 	}
 
 	@Operation(summary = "질문 목록 요청", description = "질문 목록을 보내주는 API", responses = {

--- a/src/main/java/mju/iphak/maru_egg/question/api/QuestionController.java
+++ b/src/main/java/mju/iphak/maru_egg/question/api/QuestionController.java
@@ -14,13 +14,16 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import mju.iphak.maru_egg.common.dto.pagination.SliceQuestionResponse;
 import mju.iphak.maru_egg.common.meta.CustomApiResponse;
 import mju.iphak.maru_egg.common.meta.CustomApiResponses;
 import mju.iphak.maru_egg.question.application.QuestionProcessingService;
 import mju.iphak.maru_egg.question.application.QuestionService;
 import mju.iphak.maru_egg.question.dto.request.FindQuestionsRequest;
 import mju.iphak.maru_egg.question.dto.request.QuestionRequest;
+import mju.iphak.maru_egg.question.dto.request.SearchQuestionsRequest;
 import mju.iphak.maru_egg.question.dto.response.QuestionResponse;
+import mju.iphak.maru_egg.question.dto.response.SearchedQuestionsResponse;
 
 @Tag(name = "Question API", description = "질문 관련 API 입니다.")
 @RequiredArgsConstructor
@@ -54,5 +57,19 @@ public class QuestionController {
 	@GetMapping()
 	public List<QuestionResponse> getQuestions(@Valid @ModelAttribute FindQuestionsRequest request) {
 		return questionService.getQuestions(request.type(), request.category());
+	}
+
+	@Operation(summary = "질문 자동 완성", description = "질문을 자동완성 시키는 API", responses = {
+		@ApiResponse(responseCode = "200", description = "질문 자동완성 성공")
+	})
+	@CustomApiResponses({
+		@CustomApiResponse(error = "HttpMessageNotReadableException", status = 400, message = "Invalid input format: JSON parse error: Cannot deserialize value of type `mju.iphak.maru_egg.question.domain.QuestionType` from String \\\"SUSI 또는 PYEONIP 또는 JEONGSI 또는 JAEOEGUGMIN\\\": not one of the values accepted for Enum class: [SUSI, PYEONIP, JEONGSI, JAEOEGUGMIN]", description = "validation에 맞지 않은 요청을 할 경우"),
+		@CustomApiResponse(error = "InternalServerError", status = 500, message = "내부 서버 오류가 발생했습니다.", description = "내부 서버 오류")
+	})
+	@GetMapping("/search")
+	public SliceQuestionResponse<SearchedQuestionsResponse> searchQuestions(
+		@Valid @ModelAttribute SearchQuestionsRequest request) {
+		return questionService.searchQuestionsOfCursorPaging(request.content(), request.cursorViewCount(),
+			request.questionId(), request.size());
 	}
 }

--- a/src/main/java/mju/iphak/maru_egg/question/application/QuestionProcessingService.java
+++ b/src/main/java/mju/iphak/maru_egg/question/application/QuestionProcessingService.java
@@ -1,0 +1,144 @@
+package mju.iphak.maru_egg.question.application;
+
+import static mju.iphak.maru_egg.common.exception.ErrorCode.*;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import mju.iphak.maru_egg.answer.application.AnswerService;
+import mju.iphak.maru_egg.answer.domain.Answer;
+import mju.iphak.maru_egg.answer.dto.request.LLMAskQuestionRequest;
+import mju.iphak.maru_egg.answer.dto.response.AnswerResponse;
+import mju.iphak.maru_egg.answer.dto.response.LLMAnswerResponse;
+import mju.iphak.maru_egg.question.domain.Question;
+import mju.iphak.maru_egg.question.domain.QuestionCategory;
+import mju.iphak.maru_egg.question.domain.QuestionType;
+import mju.iphak.maru_egg.question.dto.response.QuestionCore;
+import mju.iphak.maru_egg.question.dto.response.QuestionResponse;
+import mju.iphak.maru_egg.question.repository.QuestionRepository;
+import mju.iphak.maru_egg.question.utils.NLP.TextSimilarityUtils;
+import mju.iphak.maru_egg.question.utils.PhraseExtractionUtils;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+@Transactional
+public class QuestionProcessingService {
+
+	private static final double STANDARD_SIMILARITY = 0.95;
+
+	private final QuestionRepository questionRepository;
+	private final AnswerService answerService;
+
+	public QuestionResponse question(final QuestionType type, final QuestionCategory category, final String content) {
+		String contentToken = PhraseExtractionUtils.extractPhrases(content);
+		List<QuestionCore> questionCores = getQuestionCores(type, category, contentToken);
+
+		if (questionCores.isEmpty()) {
+			log.info("저장된 질문이 없어 새롭게 LLM서버에 질문을 요청합니다.");
+			return askNewQuestion(type, category, content, contentToken);
+		}
+
+		Long mostSimilarQuestionId = getMostSimilarQuestionId(questionCores, contentToken);
+
+		if (mostSimilarQuestionId != null) {
+			log.info("유사한 질문이 있어 DB에서 질문을 재사용합니다.");
+			return getExistingQuestionResponse(mostSimilarQuestionId);
+		}
+
+		log.info("유사한 질문이 없어 새롭게 LLM서버에 질문을 요청합니다.");
+		return askNewQuestion(type, category, content, contentToken);
+	}
+
+	private QuestionResponse askNewQuestion(QuestionType type, QuestionCategory category, String content,
+		String contentToken) {
+		LLMAskQuestionRequest askQuestionRequest = LLMAskQuestionRequest.of(type.toString(), category.toString(),
+			content);
+
+		LLMAnswerResponse llmAnswerResponse = answerService.askQuestion(askQuestionRequest).block();
+
+		Question newQuestion = saveQuestion(type, category, content, contentToken);
+		Answer newAnswer = saveAnswer(newQuestion, llmAnswerResponse.answer());
+		return createQuestionResponse(newQuestion, newAnswer);
+	}
+
+	private Answer saveAnswer(final Question question, final String content) {
+		Answer newAnswer = Answer.of(question, content);
+		return answerService.saveAnswer(newAnswer);
+	}
+
+	private Question saveQuestion(final QuestionType type, final QuestionCategory category, final String content,
+		final String contentToken) {
+		Question question = Question.of(content, contentToken, type, category);
+		return questionRepository.save(question);
+	}
+
+	private QuestionResponse createQuestionResponse(final Question question, final Answer answer) {
+		AnswerResponse answerResponse = AnswerResponse.from(answer);
+		return QuestionResponse.of(question, answerResponse);
+	}
+
+	private Question getQuestionById(final Long questionId) {
+		return questionRepository.findById(questionId)
+			.orElseThrow(() -> new EntityNotFoundException(
+				String.format(NOT_FOUND_QUESTION_BY_ID.getMessage(), questionId)));
+	}
+
+	private Long getMostSimilarQuestionId(final List<QuestionCore> questionCores, final String contentToken) {
+		double maxSimilarity = -1;
+		Long mostSimilarContentId = null;
+		List<String> contentTokens = questionCores.stream()
+			.map(QuestionCore::contentToken)
+			.collect(Collectors.toList());
+		Map<CharSequence, Integer> tfIdf1 = computeTfIdf(contentTokens, contentToken);
+
+		for (QuestionCore questionCore : questionCores) {
+			Map<CharSequence, Integer> tfIdf2 = computeTfIdf(contentTokens, questionCore.contentToken());
+
+			double similarity = TextSimilarityUtils.computeCosineSimilarity(tfIdf1, tfIdf2);
+
+			if (similarity > maxSimilarity) {
+				maxSimilarity = similarity;
+				mostSimilarContentId = questionCore.id();
+			}
+		}
+		if (maxSimilarity > STANDARD_SIMILARITY) {
+			return mostSimilarContentId;
+		}
+		return null;
+	}
+
+	private Map<CharSequence, Integer> computeTfIdf(List<String> contentTokens, String contentToken) {
+		try {
+			return TextSimilarityUtils.computeTfIdf(contentTokens, contentToken);
+		} catch (Exception e) {
+			throw new RuntimeException(
+				String.format(INTERNAL_ERROR_SIMILARITY.getMessage(), contentToken, contentToken));
+		}
+	}
+
+	private List<QuestionCore> getQuestionCores(final QuestionType type, final QuestionCategory category,
+		final String contentToken) {
+		if (category == null) {
+			return questionRepository.searchQuestionsByContentTokenAndType(contentToken, type)
+				.orElse(Collections.emptyList());
+		}
+		return questionRepository.searchQuestionsByContentTokenAndTypeAndCategory(contentToken, type, category)
+			.orElse(Collections.emptyList());
+	}
+
+	private QuestionResponse getExistingQuestionResponse(Long questionId) {
+		Question question = getQuestionById(questionId);
+		question.incrementViewCount();
+		Answer answer = answerService.getAnswerByQuestionId(question.getId());
+		return createQuestionResponse(question, answer);
+	}
+}

--- a/src/main/java/mju/iphak/maru_egg/question/application/QuestionService.java
+++ b/src/main/java/mju/iphak/maru_egg/question/application/QuestionService.java
@@ -1,31 +1,21 @@
 package mju.iphak.maru_egg.question.application;
 
-import static mju.iphak.maru_egg.common.exception.ErrorCode.*;
-
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import mju.iphak.maru_egg.answer.application.AnswerService;
 import mju.iphak.maru_egg.answer.domain.Answer;
-import mju.iphak.maru_egg.answer.dto.request.LLMAskQuestionRequest;
 import mju.iphak.maru_egg.answer.dto.response.AnswerResponse;
-import mju.iphak.maru_egg.answer.dto.response.LLMAnswerResponse;
 import mju.iphak.maru_egg.question.domain.Question;
 import mju.iphak.maru_egg.question.domain.QuestionCategory;
 import mju.iphak.maru_egg.question.domain.QuestionType;
-import mju.iphak.maru_egg.question.dto.response.QuestionCore;
 import mju.iphak.maru_egg.question.dto.response.QuestionResponse;
 import mju.iphak.maru_egg.question.repository.QuestionRepository;
-import mju.iphak.maru_egg.question.utils.NLP.TextSimilarityUtils;
-import mju.iphak.maru_egg.question.utils.PhraseExtractionUtils;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -33,31 +23,8 @@ import mju.iphak.maru_egg.question.utils.PhraseExtractionUtils;
 @Transactional(readOnly = true)
 public class QuestionService {
 
-	private static final double STANDARD_SIMILARITY = 0.95;
-
 	private final QuestionRepository questionRepository;
 	private final AnswerService answerService;
-
-	@Transactional
-	public QuestionResponse question(final QuestionType type, final QuestionCategory category, final String content) {
-		String contentToken = PhraseExtractionUtils.extractPhrases(content);
-		List<QuestionCore> questionCores = getQuestionCores(type, category, contentToken);
-
-		if (questionCores.isEmpty()) {
-			log.info("저장된 질문이 없어 새롭게 LLM서버에 질문을 요청합니다.");
-			return askNewQuestion(type, category, content, contentToken);
-		}
-
-		Long mostSimilarQuestionId = getMostSimilarQuestionId(questionCores, contentToken);
-
-		if (mostSimilarQuestionId != null) {
-			log.info("유사한 질문이 있어 DB에서 질문을 재사용합니다.");
-			return getExistingQuestionResponse(mostSimilarQuestionId);
-		}
-
-		log.info("유사한 질문이 없어 새롭게 LLM서버에 질문을 요청합니다.");
-		return askNewQuestion(type, category, content, contentToken);
-	}
 
 	public List<QuestionResponse> getQuestions(final QuestionType type, final QuestionCategory category) {
 		List<Question> questions = findQuestionsByTypeAndCategory(type, category);
@@ -73,87 +40,8 @@ public class QuestionService {
 		return questionRepository.findAllByQuestionTypeAndQuestionCategory(type, category);
 	}
 
-	private QuestionResponse askNewQuestion(QuestionType type, QuestionCategory category, String content,
-		String contentToken) {
-		LLMAskQuestionRequest askQuestionRequest = LLMAskQuestionRequest.of(type.toString(), category.toString(),
-			content);
-
-		LLMAnswerResponse llmAnswerResponse = answerService.askQuestion(askQuestionRequest).block();
-
-		Question newQuestion = saveQuestion(type, category, content, contentToken);
-		Answer newAnswer = saveAnswer(newQuestion, llmAnswerResponse.answer());
-		return createQuestionResponse(newQuestion, newAnswer);
-	}
-
-	private Answer saveAnswer(final Question question, final String content) {
-		Answer newAnswer = Answer.of(question, content);
-		return answerService.saveAnswer(newAnswer);
-	}
-
-	private Question saveQuestion(final QuestionType type, final QuestionCategory category, final String content,
-		final String contentToken) {
-		Question question = Question.of(content, contentToken, type, category);
-		return questionRepository.save(question);
-	}
-
 	private QuestionResponse createQuestionResponse(final Question question, final Answer answer) {
 		AnswerResponse answerResponse = AnswerResponse.from(answer);
 		return QuestionResponse.of(question, answerResponse);
-	}
-
-	private Question getQuestionById(final Long questionId) {
-		return questionRepository.findById(questionId)
-			.orElseThrow(() -> new EntityNotFoundException(
-				String.format(NOT_FOUND_QUESTION_BY_ID.getMessage(), questionId)));
-	}
-
-	private Long getMostSimilarQuestionId(final List<QuestionCore> questionCores, final String contentToken) {
-		double maxSimilarity = -1;
-		Long mostSimilarContentId = null;
-		List<String> contentTokens = questionCores.stream()
-			.map(QuestionCore::contentToken)
-			.collect(Collectors.toList());
-		Map<CharSequence, Integer> tfIdf1 = computeTfIdf(contentTokens, contentToken);
-
-		for (QuestionCore questionCore : questionCores) {
-			Map<CharSequence, Integer> tfIdf2 = computeTfIdf(contentTokens, questionCore.contentToken());
-
-			double similarity = TextSimilarityUtils.computeCosineSimilarity(tfIdf1, tfIdf2);
-
-			if (similarity > maxSimilarity) {
-				maxSimilarity = similarity;
-				mostSimilarContentId = questionCore.id();
-			}
-		}
-		if (maxSimilarity > STANDARD_SIMILARITY) {
-			return mostSimilarContentId;
-		}
-		return null;
-	}
-
-	private Map<CharSequence, Integer> computeTfIdf(List<String> contentTokens, String contentToken) {
-		try {
-			return TextSimilarityUtils.computeTfIdf(contentTokens, contentToken);
-		} catch (Exception e) {
-			throw new RuntimeException(
-				String.format(INTERNAL_ERROR_SIMILARITY.getMessage(), contentToken, contentToken));
-		}
-	}
-
-	private List<QuestionCore> getQuestionCores(final QuestionType type, final QuestionCategory category,
-		final String contentToken) {
-		if (category == null) {
-			return questionRepository.searchQuestionsByContentTokenAndType(contentToken, type)
-				.orElse(Collections.emptyList());
-		}
-		return questionRepository.searchQuestionsByContentTokenAndTypeAndCategory(contentToken, type, category)
-			.orElse(Collections.emptyList());
-	}
-
-	private QuestionResponse getExistingQuestionResponse(Long questionId) {
-		Question question = getQuestionById(questionId);
-		question.incrementViewCount();
-		Answer answer = answerService.getAnswerByQuestionId(question.getId());
-		return createQuestionResponse(question, answer);
 	}
 }

--- a/src/main/java/mju/iphak/maru_egg/question/application/QuestionService.java
+++ b/src/main/java/mju/iphak/maru_egg/question/application/QuestionService.java
@@ -3,6 +3,8 @@ package mju.iphak.maru_egg.question.application;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -11,10 +13,12 @@ import lombok.extern.slf4j.Slf4j;
 import mju.iphak.maru_egg.answer.application.AnswerService;
 import mju.iphak.maru_egg.answer.domain.Answer;
 import mju.iphak.maru_egg.answer.dto.response.AnswerResponse;
+import mju.iphak.maru_egg.common.dto.pagination.SliceQuestionResponse;
 import mju.iphak.maru_egg.question.domain.Question;
 import mju.iphak.maru_egg.question.domain.QuestionCategory;
 import mju.iphak.maru_egg.question.domain.QuestionType;
 import mju.iphak.maru_egg.question.dto.response.QuestionResponse;
+import mju.iphak.maru_egg.question.dto.response.SearchedQuestionsResponse;
 import mju.iphak.maru_egg.question.repository.QuestionRepository;
 
 @Slf4j
@@ -31,6 +35,14 @@ public class QuestionService {
 		return questions.stream()
 			.map(question -> createQuestionResponse(question, answerService.getAnswerByQuestionId(question.getId())))
 			.collect(Collectors.toList());
+	}
+
+	public SliceQuestionResponse<SearchedQuestionsResponse> searchQuestionsOfCursorPaging(final String content,
+		final Integer cursorViewCount, final Long questionId, final Integer size) {
+		Pageable pageable = PageRequest.of(0, size);
+		return questionRepository.searchQuestionsOfCursorPagingByContent(
+			content,
+			cursorViewCount, questionId, pageable);
 	}
 
 	private List<Question> findQuestionsByTypeAndCategory(final QuestionType type, final QuestionCategory category) {

--- a/src/main/java/mju/iphak/maru_egg/question/dto/request/SearchQuestionsRequest.java
+++ b/src/main/java/mju/iphak/maru_egg/question/dto/request/SearchQuestionsRequest.java
@@ -1,0 +1,29 @@
+package mju.iphak.maru_egg.question.dto.request;
+
+import org.springdoc.core.annotations.ParameterObject;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.PositiveOrZero;
+
+@Schema(description = "질문 자동완성 요청 DTO")
+@ParameterObject
+public record SearchQuestionsRequest(
+	@Schema(description = "질문 내용")
+	@NotBlank(message = "질문은 비어있을 수 없습니다.")
+	String content,
+
+	@Parameter(description = "질문 수", example = "10")
+	@PositiveOrZero
+	Integer size,
+
+	@Parameter(description = "질문 조회 수 cursor 식별값(초기 요청의 경우 0으로 입력, 이후엔 response 값의 nextCursorViewCount 사용)", example = "0")
+	@PositiveOrZero
+	Integer cursorViewCount,
+
+	@Parameter(description = "질문 ID(초기 요청의 경우 0으로 입력, 이후엔 response 값의 nextQuestionId 사용)", example = "0")
+	@PositiveOrZero
+	Long questionId
+) {
+}

--- a/src/main/java/mju/iphak/maru_egg/question/dto/response/SearchedQuestionsResponse.java
+++ b/src/main/java/mju/iphak/maru_egg/question/dto/response/SearchedQuestionsResponse.java
@@ -1,0 +1,27 @@
+package mju.iphak.maru_egg.question.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+@Schema(description = "질문 응답 DTO", example = """
+	{
+	  "id": 600697396846981500,
+	  "content": "수시 일정 알려주세요."
+	}
+	""")
+public record SearchedQuestionsResponse(
+
+	@Schema(description = "질문 ID")
+	Long id,
+
+	@Schema(description = "질문 내용")
+	String content
+) {
+	public static SearchedQuestionsResponse of(Long id, String content) {
+		return SearchedQuestionsResponse.builder()
+			.id(id)
+			.content(content)
+			.build();
+	}
+}

--- a/src/main/java/mju/iphak/maru_egg/question/repository/QuestionRepositoryCustom.java
+++ b/src/main/java/mju/iphak/maru_egg/question/repository/QuestionRepositoryCustom.java
@@ -3,14 +3,22 @@ package mju.iphak.maru_egg.question.repository;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Pageable;
+
+import mju.iphak.maru_egg.common.dto.pagination.SliceQuestionResponse;
 import mju.iphak.maru_egg.question.domain.QuestionCategory;
 import mju.iphak.maru_egg.question.domain.QuestionType;
 import mju.iphak.maru_egg.question.dto.response.QuestionCore;
+import mju.iphak.maru_egg.question.dto.response.SearchedQuestionsResponse;
 
 public interface QuestionRepositoryCustom {
-	Optional<List<QuestionCore>> searchQuestionsByContentTokenAndType(String contentToken, QuestionType type);
+	Optional<List<QuestionCore>> searchQuestionsByContentTokenAndType(final String contentToken,
+		final QuestionType type);
 
-	Optional<List<QuestionCore>> searchQuestionsByContentTokenAndTypeAndCategory(String contentToken,
-		QuestionType type,
-		QuestionCategory category);
+	Optional<List<QuestionCore>> searchQuestionsByContentTokenAndTypeAndCategory(final String contentToken,
+		final QuestionType type,
+		final QuestionCategory category);
+
+	SliceQuestionResponse<SearchedQuestionsResponse> searchQuestionsOfCursorPagingByContent(final String content,
+		final Integer cursorViewCount, final Long questionId, final Pageable pageable);
 }

--- a/src/main/java/mju/iphak/maru_egg/question/repository/QuestionRepositoryImpl.java
+++ b/src/main/java/mju/iphak/maru_egg/question/repository/QuestionRepositoryImpl.java
@@ -1,40 +1,45 @@
 package mju.iphak.maru_egg.question.repository;
 
-import static com.querydsl.core.types.dsl.Expressions.*;
 import static mju.iphak.maru_egg.question.domain.QQuestion.*;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import com.querydsl.core.Tuple;
-import com.querydsl.core.types.dsl.BooleanTemplate;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberTemplate;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
+import mju.iphak.maru_egg.common.dto.pagination.SliceQuestionResponse;
+import mju.iphak.maru_egg.question.domain.QQuestion;
+import mju.iphak.maru_egg.question.domain.Question;
 import mju.iphak.maru_egg.question.domain.QuestionCategory;
 import mju.iphak.maru_egg.question.domain.QuestionType;
 import mju.iphak.maru_egg.question.dto.response.QuestionCore;
+import mju.iphak.maru_egg.question.dto.response.SearchedQuestionsResponse;
 
 @Repository
 @RequiredArgsConstructor
 public class QuestionRepositoryImpl implements QuestionRepositoryCustom {
+
+	private static final double MIN_MATCHING_POINT = 0.005;
 
 	private final JPAQueryFactory queryFactory;
 
 	@Override
 	public Optional<List<QuestionCore>> searchQuestionsByContentTokenAndType(final String contentToken,
 		final QuestionType type) {
-		BooleanTemplate matchExpression = booleanTemplate("function('match_against', {0}, {1}) > 0", question.content,
-			contentToken);
+		NumberTemplate<Double> booleanTemplate = createBooleanTemplate(question, contentToken);
 
 		List<Tuple> tuples = queryFactory.select(question.id, question.contentToken)
 			.from(question)
-			.where(matchExpression.and(question.questionType.eq(type)))
+			.where(booleanTemplate.gt(0).and(question.questionType.eq(type)))
 			.fetch();
 
 		List<QuestionCore> result = tuples.stream()
@@ -47,19 +52,84 @@ public class QuestionRepositoryImpl implements QuestionRepositoryCustom {
 	@Override
 	public Optional<List<QuestionCore>> searchQuestionsByContentTokenAndTypeAndCategory(final String contentToken,
 		final QuestionType type, final QuestionCategory category) {
-		NumberTemplate<Double> booleanTemplate = Expressions.numberTemplate(Double.class, "function('match', {0}, {1})",
-			question.content,
-			contentToken);
+		NumberTemplate<Double> booleanTemplate = createBooleanTemplate(question, contentToken);
 
 		List<Tuple> tuples = queryFactory.select(question.id, question.contentToken)
 			.from(question)
 			.where(
-				booleanTemplate.gt(0))
+				booleanTemplate.gt(0).and(question.questionType.eq(type)).and(question.questionCategory.eq(category)))
 			.fetch();
 
 		List<QuestionCore> result = tuples.stream()
 			.map(tuple -> QuestionCore.of(tuple.get(question.id), tuple.get(question.contentToken)))
 			.collect(Collectors.toList());
 		return Optional.of(result);
+	}
+
+	@Override
+	public SliceQuestionResponse<SearchedQuestionsResponse> searchQuestionsOfCursorPagingByContent(
+		final String content,
+		final Integer cursorViewCount, final Long questionId, final Pageable pageable) {
+		QQuestion question = QQuestion.question;
+		int pageSize = pageable.getPageSize();
+
+		Integer ViewCountCursorKey =
+			cursorViewCount != null && cursorViewCount > 0 ? cursorViewCount : Integer.MAX_VALUE;
+		Long QuestionIdCursorKey = questionId != null && questionId > 0 ? questionId : Long.MAX_VALUE;
+
+		NumberTemplate<Double> booleanTemplate = createBooleanTemplate(question, content);
+		BooleanExpression cursorPredicate = createCursorPredicate(ViewCountCursorKey, QuestionIdCursorKey, question);
+
+		List<Question> questions = fetchQuestions(booleanTemplate, cursorPredicate, question, pageSize);
+
+		boolean hasNext = questions.size() > pageSize;
+
+		if (hasNext) {
+			questions.remove(pageSize);
+		}
+
+		List<SearchedQuestionsResponse> questionResponses = mapToResponse(questions);
+
+		Integer nextCursorViewCount = null;
+		Long nextQuestionId = null;
+		if (!questions.isEmpty()) {
+			Question lastQuestion = questions.get(questions.size() - 1);
+			nextCursorViewCount = lastQuestion.getViewCount();
+			nextQuestionId = lastQuestion.getId();
+		}
+
+		return new SliceQuestionResponse<>(questionResponses, pageable.getPageNumber(), pageSize, hasNext,
+			nextCursorViewCount, nextQuestionId);
+	}
+
+	private NumberTemplate<Double> createBooleanTemplate(QQuestion question, String content) {
+		return Expressions.numberTemplate(Double.class, "function('match', {0}, {1})", question.content, content);
+	}
+
+	private BooleanExpression createCursorPredicate(Integer cursorViewCount, Long questionId, QQuestion question) {
+		if (cursorViewCount != null && questionId != null) {
+			return question.viewCount.lt(cursorViewCount)
+				.or(question.viewCount.eq(cursorViewCount).and(question.id.lt(questionId)));
+		} else if (cursorViewCount != null) {
+			return question.viewCount.lt(cursorViewCount);
+		} else if (questionId != null) {
+			return question.id.lt(questionId);
+		}
+		return null;
+	}
+
+	private List<Question> fetchQuestions(NumberTemplate<Double> booleanTemplate, BooleanExpression cursorPredicate,
+		QQuestion question, int pageSize) {
+		return queryFactory.selectFrom(question)
+			.where(booleanTemplate.gt(MIN_MATCHING_POINT), cursorPredicate)
+			.orderBy(question.viewCount.desc(), question.id.desc())
+			.limit(pageSize + 1)
+			.fetch();
+	}
+
+	private List<SearchedQuestionsResponse> mapToResponse(List<Question> questions) {
+		return questions.stream()
+			.map(q -> SearchedQuestionsResponse.of(q.getId(), q.getContent()))
+			.collect(Collectors.toList());
 	}
 }

--- a/src/main/java/mju/iphak/maru_egg/question/utils/PhraseExtractionUtils.java
+++ b/src/main/java/mju/iphak/maru_egg/question/utils/PhraseExtractionUtils.java
@@ -12,7 +12,7 @@ import scala.collection.Seq;
 public class PhraseExtractionUtils {
 	public static List<String> extractTokens(List<KoreanTokenizer.KoreanToken> tokens) {
 		return tokens.stream()
-			.filter(token -> token.pos().toString().equals("Noun"))
+			.filter(token -> token.pos().toString().equals("Noun") || token.pos().toString().equals("Number"))
 			.map(token -> token.text().toString())
 			.collect(Collectors.toList());
 	}

--- a/src/test/java/mju/iphak/maru_egg/question/api/QuestionControllerTest.java
+++ b/src/test/java/mju/iphak/maru_egg/question/api/QuestionControllerTest.java
@@ -17,6 +17,7 @@ import org.springframework.test.web.servlet.ResultActions;
 import mju.iphak.maru_egg.answer.domain.Answer;
 import mju.iphak.maru_egg.answer.dto.response.AnswerResponse;
 import mju.iphak.maru_egg.common.IntegrationTest;
+import mju.iphak.maru_egg.question.application.QuestionProcessingService;
 import mju.iphak.maru_egg.question.application.QuestionService;
 import mju.iphak.maru_egg.question.domain.Question;
 import mju.iphak.maru_egg.question.domain.QuestionCategory;
@@ -32,7 +33,11 @@ import mju.iphak.maru_egg.question.dto.response.QuestionResponse;
 class QuestionControllerTest extends IntegrationTest {
 
 	@MockBean
+	private QuestionProcessingService questionProcessingService;
+
+	@MockBean
 	private QuestionService questionService;
+
 	private Question question;
 	private Answer answer;
 	private QuestionType type;
@@ -59,7 +64,7 @@ class QuestionControllerTest extends IntegrationTest {
 		QuestionResponse response = QuestionResponse.of(question, answerResponse);
 
 		// when
-		when(questionService.question(type, category, content)).thenReturn(response);
+		when(questionProcessingService.question(type, category, content)).thenReturn(response);
 		ResultActions resultActions = requestCreateQuestion(request);
 
 		// then

--- a/src/test/java/mju/iphak/maru_egg/question/api/QuestionControllerTest.java
+++ b/src/test/java/mju/iphak/maru_egg/question/api/QuestionControllerTest.java
@@ -17,6 +17,7 @@ import org.springframework.test.web.servlet.ResultActions;
 import mju.iphak.maru_egg.answer.domain.Answer;
 import mju.iphak.maru_egg.answer.dto.response.AnswerResponse;
 import mju.iphak.maru_egg.common.IntegrationTest;
+import mju.iphak.maru_egg.common.dto.pagination.SliceQuestionResponse;
 import mju.iphak.maru_egg.question.application.QuestionProcessingService;
 import mju.iphak.maru_egg.question.application.QuestionService;
 import mju.iphak.maru_egg.question.domain.Question;
@@ -24,7 +25,9 @@ import mju.iphak.maru_egg.question.domain.QuestionCategory;
 import mju.iphak.maru_egg.question.domain.QuestionType;
 import mju.iphak.maru_egg.question.dto.request.FindQuestionsRequest;
 import mju.iphak.maru_egg.question.dto.request.QuestionRequest;
+import mju.iphak.maru_egg.question.dto.request.SearchQuestionsRequest;
 import mju.iphak.maru_egg.question.dto.response.QuestionResponse;
+import mju.iphak.maru_egg.question.dto.response.SearchedQuestionsResponse;
 
 @TestPropertySource(properties = {
 	"web-client.base-url=http://localhost:8080",
@@ -118,6 +121,27 @@ class QuestionControllerTest extends IntegrationTest {
 			.andExpect(jsonPath("$[0].answer.renewalYear").value(answerResponse.renewalYear()));
 	}
 
+	@Test
+	void 질문_자동완성_API() throws Exception {
+		// given
+		SearchQuestionsRequest request = new SearchQuestionsRequest("example content", 5, 0, 0L);
+		SearchedQuestionsResponse searchedQuestionsResponse = new SearchedQuestionsResponse(1L, "example content");
+		SliceQuestionResponse<SearchedQuestionsResponse> response = new SliceQuestionResponse<>(
+			List.of(searchedQuestionsResponse), 0, 5, false, null, null);
+
+		// when
+		when(questionService.searchQuestionsOfCursorPaging(request.content(), request.cursorViewCount(),
+			request.questionId(), request.size()))
+			.thenReturn(response);
+		ResultActions resultActions = requestSearchQuestions(request);
+
+		// then
+		resultActions
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data[0].content").value("example content"))
+			.andExpect(jsonPath("$.hasNext").value(false));
+	}
+
 	private ResultActions requestCreateQuestion(QuestionRequest dto) throws Exception {
 		return mvc.perform(post("/api/questions")
 				.contentType(MediaType.APPLICATION_JSON)
@@ -136,6 +160,16 @@ class QuestionControllerTest extends IntegrationTest {
 	private ResultActions requestFindQuestionsWithoutCategory(FindQuestionsRequest dto) throws Exception {
 		return mvc.perform(get("/api/questions")
 				.param("type", dto.type().name())
+				.contentType(MediaType.APPLICATION_JSON))
+			.andDo(print());
+	}
+
+	private ResultActions requestSearchQuestions(SearchQuestionsRequest dto) throws Exception {
+		return mvc.perform(get("/api/questions/search")
+				.param("content", dto.content())
+				.param("size", dto.size().toString())
+				.param("cursorViewCount", dto.cursorViewCount().toString())
+				.param("questionId", dto.questionId().toString())
 				.contentType(MediaType.APPLICATION_JSON))
 			.andDo(print());
 	}

--- a/src/test/java/mju/iphak/maru_egg/question/application/QuestionProcessingServiceTest.java
+++ b/src/test/java/mju/iphak/maru_egg/question/application/QuestionProcessingServiceTest.java
@@ -1,0 +1,251 @@
+package mju.iphak.maru_egg.question.application;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.reactive.ClientHttpConnector;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import com.google.gson.Gson;
+
+import mju.iphak.maru_egg.answer.application.AnswerService;
+import mju.iphak.maru_egg.answer.domain.Answer;
+import mju.iphak.maru_egg.answer.dto.request.LLMAskQuestionRequest;
+import mju.iphak.maru_egg.answer.dto.response.AnswerResponse;
+import mju.iphak.maru_egg.answer.dto.response.LLMAnswerResponse;
+import mju.iphak.maru_egg.answer.repository.AnswerRepository;
+import mju.iphak.maru_egg.common.MockTest;
+import mju.iphak.maru_egg.question.domain.Question;
+import mju.iphak.maru_egg.question.domain.QuestionCategory;
+import mju.iphak.maru_egg.question.domain.QuestionType;
+import mju.iphak.maru_egg.question.dto.response.QuestionCore;
+import mju.iphak.maru_egg.question.dto.response.QuestionResponse;
+import mju.iphak.maru_egg.question.repository.QuestionRepository;
+import mju.iphak.maru_egg.question.utils.PhraseExtractionUtils;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import reactor.core.publisher.Mono;
+
+@TestPropertySource(properties = {
+	"web-client.base-url=http://localhost:8080",
+	"JWT_SECRET=my_test_secret_key"
+})
+class QuestionProcessingServiceTest extends MockTest {
+
+	@Mock
+	private QuestionRepository questionRepository;
+
+	@Mock
+	private AnswerRepository answerRepository;
+
+	@Mock
+	private AnswerService answerService;
+	private MockWebServer mockWebServer;
+
+	@InjectMocks
+	private QuestionProcessingService questionProcessingService;
+
+	private LLMAnswerResponse mockAskQuestion(LLMAskQuestionRequest request) {
+		startServer(new ReactorClientHttpConnector());
+		MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+		formData.add("questionType", request.questionType());
+		formData.add("questionCategory", request.questionCategory());
+		formData.add("question", request.question());
+		Question testQuestion = Question.of("새로운 질문입니다.", "새로운 질문", QuestionType.SUSI,
+			QuestionCategory.ADMISSION_GUIDELINE);
+		LLMAnswerResponse expectedResponse = LLMAnswerResponse.from(Answer.of(testQuestion, "새로운 답변입니다."));
+
+		mockWebServer.enqueue(new MockResponse()
+			.setHeader("Content-type", MediaType.APPLICATION_JSON_VALUE)
+			.setHeader("Accept", MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+			.setResponseCode(200)
+			.setBody(new Gson().toJson(expectedResponse))
+		);
+
+		return answerService.askQuestion(request).block();
+	}
+
+	void startServer(ClientHttpConnector connector) {
+		this.mockWebServer = new MockWebServer();
+		answerService = new AnswerService(answerRepository, WebClient
+			.builder()
+			.baseUrl(this.mockWebServer.url("/").toString())
+			.clientConnector(connector).build()
+		);
+	}
+
+	@AfterEach
+	void shutdown() throws IOException {
+		if (mockWebServer != null) {
+			this.mockWebServer.shutdown();
+		}
+	}
+
+	private Question question;
+	private Answer answer;
+
+	@BeforeEach
+	void setUp() {
+		MockitoAnnotations.openMocks(this);
+
+		question = mock(Question.class);
+		answer = mock(Answer.class);
+
+		when(question.getId()).thenReturn(1L);
+		when(answer.getId()).thenReturn(1L);
+		when(answerService.getAnswerByQuestionId(1L)).thenReturn(answer);
+		when(answerRepository.findByQuestionId(anyLong())).thenReturn(Optional.of(answer));
+		when(questionRepository.searchQuestionsByContentTokenAndTypeAndCategory(anyString(), any(QuestionType.class),
+			any(QuestionCategory.class)))
+			.thenReturn(Optional.of(List.of(QuestionCore.of(1L, "테스트 질문입니다."))));
+		when(questionRepository.findById(1L)).thenReturn(Optional.of(question));
+		questionProcessingService = new QuestionProcessingService(questionRepository, answerService);
+
+		doAnswer(invocation -> {
+			LLMAskQuestionRequest request = invocation.getArgument(0);
+			return Mono.just(mockAskQuestion(request));
+		}).when(answerService).askQuestion(any(LLMAskQuestionRequest.class));
+	}
+
+	@DisplayName("질문을 조회하는데 성공한 경우")
+	@Test
+	void 질문_조회_성공() {
+		// given
+		startServer(new ReactorClientHttpConnector());
+		QuestionType type = QuestionType.SUSI;
+		QuestionCategory category = QuestionCategory.ADMISSION_GUIDELINE;
+		String content = "테스트 질문입니다.";
+		String contentToken = PhraseExtractionUtils.extractPhrases(content);
+
+		when(questionRepository.searchQuestionsByContentTokenAndTypeAndCategory(anyString(), eq(type), eq(category)))
+			.thenReturn(Optional.of(List.of(QuestionCore.of(1L, contentToken))));
+
+		// when
+		QuestionResponse result = questionProcessingService.question(type, category, content);
+
+		// then
+		assertThat(result).isEqualTo(QuestionResponse.of(question, AnswerResponse.from(answer)));
+	}
+
+	// TODO: 추후 test
+	// @DisplayName("유사한 질문을 찾지 못한 경우 새로운 질문을 생성")
+	// @Test
+	// void 유사한_질문_없음_새로운_질문_생성() {
+	// 	// given
+	// 	QuestionType type = QuestionType.SUSI;
+	// 	QuestionCategory category = QuestionCategory.ADMISSION_GUIDELINE;
+	// 	String content = "새로운 질문입니다.";
+	// 	String contentToken = "새로운 질문";
+	// 	Question testQuestion = Question.of(content, contentToken, type, category);
+	// 	Answer testAnswer = Answer.of(testQuestion, "새로운 답변입니다.");
+	//
+	// 	when(questionRepository.searchQuestionsByContentTokenAndTypeAndCategory(contentToken, type, category))
+	// 		.thenReturn(Optional.of(Collections.emptyList()));
+	// 	when(questionRepository.save(any(Question.class))).thenReturn(testQuestion);
+	// 	when(answerService.saveAnswer(any(Answer.class))).thenReturn(testAnswer);
+	// 	doAnswer(invocation -> {
+	// 		LLMAskQuestionRequest request = invocation.getArgument(0);
+	// 		return Mono.just(mockAskQuestion(request));
+	// 	}).when(answerService).askQuestion(any(LLMAskQuestionRequest.class));
+	//
+	// 	// when
+	// 	QuestionResponse result = questionService.question(type, category, content);
+	//
+	// 	// then
+	// 	verify(questionRepository, times(1)).searchQuestionsByContentTokenAndTypeAndCategory(anyString(), eq(type),
+	// 		eq(category));
+	// 	verify(answerService, times(1)).askQuestion(any(LLMAskQuestionRequest.class));
+	// }
+
+	// @DisplayName("유사한 질문이 있는 경우 기존 질문을 반환")
+	// @Test
+	// void 유사한_질문_있음_기존_질문_반환() throws Exception {
+	// 	// given
+	// 	QuestionType type = QuestionType.SUSI;
+	// 	QuestionCategory category = QuestionCategory.ADMISSION_GUIDELINE;
+	// 	String content = "유사한 테스트 질문입니다.";
+	// 	String contentToken = PhraseExtractionUtils.extractPhrases(content);
+	// 	double similarityScore = 0.98;
+	// 	Map<CharSequence, Integer> tfIdfDummyMap = new HashMap<>();
+	// 	tfIdfDummyMap.put("질문", 1);
+	//
+	// 	when(questionRepository.searchQuestionsByContentTokenAndTypeAndCategory(anyString(), eq(type), eq(category)))
+	// 		.thenReturn(Optional.of(List.of(QuestionCoreDTO.of(1L, contentToken))));
+	// 	when(TextSimilarityUtils.computeTfIdf(anyList(), anyString())).thenReturn(tfIdfDummyMap);
+	// 	when(TextSimilarityUtils.computeCosineSimilarity(anyMap(), anyMap())).thenReturn(similarityScore);
+	// 	// when
+	// 	QuestionResponse result = questionService.question(type, category, content);
+	//
+	// 	// then
+	// 	assertNotNull(result);
+	// 	assertEquals("테스트 답변입니다.", result.answer().content());
+	// }
+
+	@DisplayName("질문이 없을 때 새로운 질문을 요청하는지 확인")
+	@Test
+	void 질문_없을_때_새로운_질문_요청() {
+		// given
+		QuestionType type = QuestionType.SUSI;
+		QuestionCategory category = QuestionCategory.ADMISSION_GUIDELINE;
+		String content = "새로운 질문입니다.";
+		String contentToken = PhraseExtractionUtils.extractPhrases(content);
+		Question testQuestion = Question.of(content, contentToken, type, category);
+		Answer testAnswer = Answer.of(testQuestion, "새로운 답변입니다.");
+		LLMAnswerResponse expectedResponse = LLMAnswerResponse.from(testAnswer);
+
+		when(questionRepository.searchQuestionsByContentTokenAndTypeAndCategory(contentToken, type, category))
+			.thenReturn(Optional.of(Collections.emptyList()));
+		when(questionRepository.save(any(Question.class))).thenReturn(testQuestion);
+		when(answerService.saveAnswer(any(Answer.class))).thenReturn(testAnswer);
+		doAnswer(invocation -> {
+			LLMAskQuestionRequest request = invocation.getArgument(0);
+			return Mono.just(mockAskQuestion(request));
+		}).when(answerService).askQuestion(any(LLMAskQuestionRequest.class));
+
+		// when
+		QuestionResponse result = questionProcessingService.question(type, category, content);
+
+		// then
+		assertNotNull(result);
+		assertThat(result.answer().content()).isEqualTo(expectedResponse.answer());
+	}
+
+	@DisplayName("MOCK LLM 서버에 질문을 요청합니다.")
+	@Test
+	public void MOCK_LLM_질문_요청() {
+		// given
+		startServer(new ReactorClientHttpConnector());
+		LLMAskQuestionRequest request = LLMAskQuestionRequest.of(QuestionType.SUSI.toString(),
+			QuestionCategory.ADMISSION_GUIDELINE.toString(),
+			question.getContent());
+		Question testQuestion = Question.of("새로운 질문입니다.", "새로운 질문", QuestionType.SUSI,
+			QuestionCategory.ADMISSION_GUIDELINE);
+		LLMAnswerResponse expectedResponse = LLMAnswerResponse.from(Answer.of(testQuestion, "새로운 답변입니다."));
+
+		// when
+		LLMAnswerResponse result = mockAskQuestion(request);
+
+		// then
+		assertThat(result).isEqualTo(expectedResponse);
+	}
+
+}

--- a/src/test/java/mju/iphak/maru_egg/question/application/QuestionServiceTest.java
+++ b/src/test/java/mju/iphak/maru_egg/question/application/QuestionServiceTest.java
@@ -6,7 +6,6 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -30,7 +29,6 @@ import com.google.gson.Gson;
 import mju.iphak.maru_egg.answer.application.AnswerService;
 import mju.iphak.maru_egg.answer.domain.Answer;
 import mju.iphak.maru_egg.answer.dto.request.LLMAskQuestionRequest;
-import mju.iphak.maru_egg.answer.dto.response.AnswerResponse;
 import mju.iphak.maru_egg.answer.dto.response.LLMAnswerResponse;
 import mju.iphak.maru_egg.answer.repository.AnswerRepository;
 import mju.iphak.maru_egg.common.MockTest;
@@ -40,7 +38,6 @@ import mju.iphak.maru_egg.question.domain.QuestionType;
 import mju.iphak.maru_egg.question.dto.response.QuestionCore;
 import mju.iphak.maru_egg.question.dto.response.QuestionResponse;
 import mju.iphak.maru_egg.question.repository.QuestionRepository;
-import mju.iphak.maru_egg.question.utils.PhraseExtractionUtils;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import reactor.core.publisher.Mono;
@@ -126,26 +123,6 @@ class QuestionServiceTest extends MockTest {
 		}).when(answerService).askQuestion(any(LLMAskQuestionRequest.class));
 	}
 
-	@DisplayName("질문을 조회하는데 성공한 경우")
-	@Test
-	void 질문_조회_성공() {
-		// given
-		startServer(new ReactorClientHttpConnector());
-		QuestionType type = QuestionType.SUSI;
-		QuestionCategory category = QuestionCategory.ADMISSION_GUIDELINE;
-		String content = "테스트 질문입니다.";
-		String contentToken = PhraseExtractionUtils.extractPhrases(content);
-
-		when(questionRepository.searchQuestionsByContentTokenAndTypeAndCategory(anyString(), eq(type), eq(category)))
-			.thenReturn(Optional.of(List.of(QuestionCore.of(1L, contentToken))));
-
-		// when
-		QuestionResponse result = questionService.question(type, category, content);
-
-		// then
-		assertThat(result).isEqualTo(QuestionResponse.of(question, AnswerResponse.from(answer)));
-	}
-
 	@DisplayName("질문 목록을 조회하는데 성공한 경우")
 	@Test
 	void 질문_목록_조회_성공() {
@@ -167,89 +144,6 @@ class QuestionServiceTest extends MockTest {
 		assertThat(result.get(0).answer().content()).isEqualTo(answer.getContent());
 	}
 
-	// TODO: 추후 test
-	// @DisplayName("유사한 질문을 찾지 못한 경우 새로운 질문을 생성")
-	// @Test
-	// void 유사한_질문_없음_새로운_질문_생성() {
-	// 	// given
-	// 	QuestionType type = QuestionType.SUSI;
-	// 	QuestionCategory category = QuestionCategory.ADMISSION_GUIDELINE;
-	// 	String content = "새로운 질문입니다.";
-	// 	String contentToken = "새로운 질문";
-	// 	Question testQuestion = Question.of(content, contentToken, type, category);
-	// 	Answer testAnswer = Answer.of(testQuestion, "새로운 답변입니다.");
-	//
-	// 	when(questionRepository.searchQuestionsByContentTokenAndTypeAndCategory(contentToken, type, category))
-	// 		.thenReturn(Optional.of(Collections.emptyList()));
-	// 	when(questionRepository.save(any(Question.class))).thenReturn(testQuestion);
-	// 	when(answerService.saveAnswer(any(Answer.class))).thenReturn(testAnswer);
-	// 	doAnswer(invocation -> {
-	// 		LLMAskQuestionRequest request = invocation.getArgument(0);
-	// 		return Mono.just(mockAskQuestion(request));
-	// 	}).when(answerService).askQuestion(any(LLMAskQuestionRequest.class));
-	//
-	// 	// when
-	// 	QuestionResponse result = questionService.question(type, category, content);
-	//
-	// 	// then
-	// 	verify(questionRepository, times(1)).searchQuestionsByContentTokenAndTypeAndCategory(anyString(), eq(type),
-	// 		eq(category));
-	// 	verify(answerService, times(1)).askQuestion(any(LLMAskQuestionRequest.class));
-	// }
-
-	// @DisplayName("유사한 질문이 있는 경우 기존 질문을 반환")
-	// @Test
-	// void 유사한_질문_있음_기존_질문_반환() throws Exception {
-	// 	// given
-	// 	QuestionType type = QuestionType.SUSI;
-	// 	QuestionCategory category = QuestionCategory.ADMISSION_GUIDELINE;
-	// 	String content = "유사한 테스트 질문입니다.";
-	// 	String contentToken = PhraseExtractionUtils.extractPhrases(content);
-	// 	double similarityScore = 0.98;
-	// 	Map<CharSequence, Integer> tfIdfDummyMap = new HashMap<>();
-	// 	tfIdfDummyMap.put("질문", 1);
-	//
-	// 	when(questionRepository.searchQuestionsByContentTokenAndTypeAndCategory(anyString(), eq(type), eq(category)))
-	// 		.thenReturn(Optional.of(List.of(QuestionCoreDTO.of(1L, contentToken))));
-	// 	when(TextSimilarityUtils.computeTfIdf(anyList(), anyString())).thenReturn(tfIdfDummyMap);
-	// 	when(TextSimilarityUtils.computeCosineSimilarity(anyMap(), anyMap())).thenReturn(similarityScore);
-	// 	// when
-	// 	QuestionResponse result = questionService.question(type, category, content);
-	//
-	// 	// then
-	// 	assertNotNull(result);
-	// 	assertEquals("테스트 답변입니다.", result.answer().content());
-	// }
-
-	@DisplayName("질문이 없을 때 새로운 질문을 요청하는지 확인")
-	@Test
-	void 질문_없을_때_새로운_질문_요청() {
-		// given
-		QuestionType type = QuestionType.SUSI;
-		QuestionCategory category = QuestionCategory.ADMISSION_GUIDELINE;
-		String content = "새로운 질문입니다.";
-		String contentToken = PhraseExtractionUtils.extractPhrases(content);
-		Question testQuestion = Question.of(content, contentToken, type, category);
-		Answer testAnswer = Answer.of(testQuestion, "새로운 답변입니다.");
-		LLMAnswerResponse expectedResponse = LLMAnswerResponse.from(testAnswer);
-
-		when(questionRepository.searchQuestionsByContentTokenAndTypeAndCategory(contentToken, type, category))
-			.thenReturn(Optional.of(Collections.emptyList()));
-		when(questionRepository.save(any(Question.class))).thenReturn(testQuestion);
-		when(answerService.saveAnswer(any(Answer.class))).thenReturn(testAnswer);
-		doAnswer(invocation -> {
-			LLMAskQuestionRequest request = invocation.getArgument(0);
-			return Mono.just(mockAskQuestion(request));
-		}).when(answerService).askQuestion(any(LLMAskQuestionRequest.class));
-
-		// when
-		QuestionResponse result = questionService.question(type, category, content);
-
-		// then
-		assertNotNull(result);
-		assertThat(result.answer().content()).isEqualTo(expectedResponse.answer());
-	}
-
 	@DisplayName("질문 목록을 조회하는데 성공한 경우 - category 없이 type으로 조회")
 	@Test
 	void 질문_목록_조회_성공_카테고리_없이() {
@@ -268,25 +162,6 @@ class QuestionServiceTest extends MockTest {
 		assertFalse(result.isEmpty());
 		assertThat(result.get(0).content()).isEqualTo(question.getContent());
 		assertThat(result.get(0).answer().content()).isEqualTo(answer.getContent());
-	}
-
-	@DisplayName("MOCK LLM 서버에 질문을 요청합니다.")
-	@Test
-	public void MOCK_LLM_질문_요청() {
-		// given
-		startServer(new ReactorClientHttpConnector());
-		LLMAskQuestionRequest request = LLMAskQuestionRequest.of(QuestionType.SUSI.toString(),
-			QuestionCategory.ADMISSION_GUIDELINE.toString(),
-			question.getContent());
-		Question testQuestion = Question.of("새로운 질문입니다.", "새로운 질문", QuestionType.SUSI,
-			QuestionCategory.ADMISSION_GUIDELINE);
-		LLMAnswerResponse expectedResponse = LLMAnswerResponse.from(Answer.of(testQuestion, "새로운 답변입니다."));
-
-		// when
-		LLMAnswerResponse result = mockAskQuestion(request);
-
-		// then
-		assertThat(result).isEqualTo(expectedResponse);
 	}
 
 }

--- a/src/test/java/mju/iphak/maru_egg/question/repository/QuestionRepositoryImplTest.java
+++ b/src/test/java/mju/iphak/maru_egg/question/repository/QuestionRepositoryImplTest.java
@@ -47,7 +47,6 @@ class QuestionRepositoryImplTest extends RepositoryTest {
 	@Autowired
 	private JdbcTemplate jdbcTemplate;
 
-	@Autowired
 	private JPAQueryFactory queryFactory;
 
 	private Question question;
@@ -55,6 +54,8 @@ class QuestionRepositoryImplTest extends RepositoryTest {
 
 	@BeforeEach
 	public void setUp() throws Exception {
+		queryFactory = new JPAQueryFactory(em);
+
 		String checkIndexQuery = "SHOW INDEX FROM questions WHERE Key_name = 'idx_ft_question_content'";
 		List<?> result = jdbcTemplate.queryForList(checkIndexQuery);
 		if (!result.isEmpty()) {
@@ -63,48 +64,61 @@ class QuestionRepositoryImplTest extends RepositoryTest {
 
 		jdbcTemplate.execute("ALTER TABLE questions ADD FULLTEXT INDEX idx_ft_question_content(content)");
 
+		// 데이터 삽입
 		jdbcTemplate.update(
 			"INSERT INTO questions (id, content, content_token, question_type, question_category, view_count) VALUES (?, ?, ?, ?, ?, ?)",
-			1L, "테스트 질문 예시 예시입니다.", "테스트 질문 예시", QuestionType.SUSI.name(), QuestionCategory.ADMISSION_GUIDELINE.name(),
-			0);
-		question = questionRepository.findById(1L).orElseThrow();
+			1L, "수시 입학 요강에 대해 알려주세요.", "수시 입학 요강 대해", QuestionType.SUSI.name(),
+			QuestionCategory.ADMISSION_GUIDELINE.name(), 0);
+		jdbcTemplate.update(
+			"INSERT INTO questions (id, content, content_token, question_type, question_category, view_count) VALUES (?, ?, ?, ?, ?, ?)",
+			2L, "수시 시험 일정 알려줘", "수시 시험 일정", QuestionType.SUSI.name(), QuestionCategory.ADMISSION_GUIDELINE.name(), 0);
+		jdbcTemplate.update(
+			"INSERT INTO questions (id, content, content_token, question_type, question_category, view_count) VALUES (?, ?, ?, ?, ?, ?)",
+			3L, "수시 시기 알려줘", "수시 시기", QuestionType.SUSI.name(), QuestionCategory.ADMISSION_GUIDELINE.name(), 0);
+		jdbcTemplate.update(
+			"INSERT INTO questions (id, content, content_token, question_type, question_category, view_count) VALUES (?, ?, ?, ?, ?, ?)",
+			4L, "수시 면접 일정 알려줘", "수시 면접 일정", QuestionType.SUSI.name(), QuestionCategory.ADMISSION_GUIDELINE.name(), 0);
+		jdbcTemplate.update(
+			"INSERT INTO questions (id, content, content_token, question_type, question_category, view_count) VALUES (?, ?, ?, ?, ?, ?)",
+			5L, "수시", "수시", QuestionType.SUSI.name(), QuestionCategory.ADMISSION_GUIDELINE.name(), 0);
+		jdbcTemplate.update(
+			"INSERT INTO questions (id, content, content_token, question_type, question_category, view_count) VALUES (?, ?, ?, ?, ?, ?)",
+			6L, "2024 정시 입학 요강에 대해 알려주세요.", "정시 입학 요강 대해", QuestionType.SUSI.name(),
+			QuestionCategory.ADMISSION_GUIDELINE.name(), 0);
+		jdbcTemplate.update(
+			"INSERT INTO questions (id, content, content_token, question_type, question_category, view_count) VALUES (?, ?, ?, ?, ?, ?)",
+			7L, "시기 알려줘", "시기", QuestionType.SUSI.name(), QuestionCategory.ADMISSION_GUIDELINE.name(), 0);
+		jdbcTemplate.update(
+			"INSERT INTO questions (id, content, content_token, question_type, question_category, view_count) VALUES (?, ?, ?, ?, ?, ?)",
+			8L, "2024 장시 입학 요강에 대해 알려주세요.", "장시 입학 요강 대해", QuestionType.SUSI.name(),
+			QuestionCategory.ADMISSION_GUIDELINE.name(), 0);
+		jdbcTemplate.update(
+			"INSERT INTO questions (id, content, content_token, question_type, question_category, view_count) VALUES (?, ?, ?, ?, ?, ?)",
+			9L, "2024 수시 입학 요강에 대해 알려주세요.", "2024 수시 입학 요강 대해", QuestionType.SUSI.name(),
+			QuestionCategory.ADMISSION_GUIDELINE.name(), 0);
 
-		jdbcTemplate.update(
-			"INSERT INTO questions (id, content, content_token, question_type, question_category, view_count) VALUES (?, ?, ?, ?, ?, ?)",
-			2L, "추가1 테스트 질문 예시입니다.", "추가 테스트 질문 예시", QuestionType.SUSI.name(),
-			QuestionCategory.ADMISSION_GUIDELINE.name(), 0);
-		jdbcTemplate.update(
-			"INSERT INTO questions (id, content, content_token, question_type, question_category, view_count) VALUES (?, ?, ?, ?, ?, ?)",
-			3L, "추가2 테스트 질문 예시입니다.", "추가 테스트 질문 예시", QuestionType.SUSI.name(),
-			QuestionCategory.ADMISSION_GUIDELINE.name(), 0);
-		jdbcTemplate.update(
-			"INSERT INTO questions (id, content, content_token, question_type, question_category, view_count) VALUES (?, ?, ?, ?, ?, ?)",
-			4L, "추가3 테스트 질문 예시입니다.", "추가 테스트 질문 예시", QuestionType.SUSI.name(),
-			QuestionCategory.ADMISSION_GUIDELINE.name(), 0);
-		jdbcTemplate.update(
-			"INSERT INTO questions (id, content, content_token, question_type, question_category, view_count) VALUES (?, ?, ?, ?, ?, ?)",
-			5L, "추가4 테스트 질문 예시입니다.", "추가 테스트 질문 예시", QuestionType.SUSI.name(), QuestionCategory.ETC.name(), 0);
+		question = questionRepository.findById(1L).orElseThrow();
 
 		answer = Answer.of(question, "테스트 답변입니다.");
 		answerRepository.save(answer);
 	}
 
-	@DisplayName("contentToken, type으로 질문을 검색하는데 성공")
 	@Test
 	void contentToken_type_질문_검색_성공() {
 		// given
-		String contentToken = "테스트 질문 예시";
+		QQuestion question = QQuestion.question;
+		String contentToken = "수시 입학 요강 대해";
 		QuestionType type = QuestionType.SUSI;
+		NumberTemplate<Double> numberTemplate = createBooleanTemplate(question, contentToken);
 
 		// when
-		Optional<List<QuestionCore>> result = questionRepositoryImpl.searchQuestionsByContentTokenAndType(contentToken,
-			type);
+		List<Question> results = queryFactory.selectFrom(question)
+			.where(numberTemplate.gt(0.0).or(numberTemplate.eq(0.0)).and(question.questionType.eq(type)))
+			.fetch();
 
 		// then
-		assertThat(result).isPresent();
-		List<QuestionCore> questionCores = result.get();
-		assertThat(questionCores).isNotEmpty();
-		assertThat(questionCores.get(0).id()).isEqualTo(question.getId());
+		assertThat(results).isNotEmpty();
+		assertThat(results.get(0).getContent()).contains("수시 입학 요강");
 	}
 
 	@DisplayName("contentToken, type으로 질문을 검색하는데 실패한 경우")
@@ -127,19 +141,23 @@ class QuestionRepositoryImplTest extends RepositoryTest {
 	@Test
 	void contentToken_type_Category로_질문_검색_성공() {
 		// given
-		String contentToken = "테스트 질문 예시";
+		QQuestion question = QQuestion.question;
+		String contentToken = "수시 입학 요강 대해";
 		QuestionType type = QuestionType.SUSI;
 		QuestionCategory category = QuestionCategory.ADMISSION_GUIDELINE;
+		NumberTemplate<Double> numberTemplate = createBooleanTemplate(question, contentToken);
 
 		// when
-		Optional<List<QuestionCore>> result = questionRepositoryImpl.searchQuestionsByContentTokenAndTypeAndCategory(
-			contentToken, type, category);
+		List<String> results = queryFactory.select(question.contentToken)
+			.from(question)
+			.where(numberTemplate.gt(0.0)
+				.or(numberTemplate.eq(0.0))
+				.and(question.questionType.eq(type))
+				.and(question.questionCategory.eq(category)))
+			.fetch();
 
 		// then
-		assertThat(result).isPresent();
-		List<QuestionCore> questionCores = result.get();
-		assertThat(questionCores).isNotEmpty();
-		assertThat(questionCores.get(0).id()).isEqualTo(question.getId());
+		assertThat(results).isNotEmpty();
 	}
 
 	@DisplayName("contentToken, type, Category로 질문을 검색하는데 실패한 경우")
@@ -159,23 +177,6 @@ class QuestionRepositoryImplTest extends RepositoryTest {
 		assertThat(result.get()).isEmpty();
 	}
 
-	@DisplayName("content로 질문을 페이지네이션 조회 - 성공")
-	@Test
-	void content로_질문_페이지네이션_조회_성공() {
-		// given
-		String content = "테스트 질문 예시";
-		Pageable pageable = PageRequest.of(0, 3);
-
-		// when
-		SliceQuestionResponse<SearchedQuestionsResponse> result = questionRepositoryImpl.searchQuestionsOfCursorPagingByContent(
-			content, null, null, pageable);
-
-		// then
-		assertThat(result.data()).isNotEmpty();
-		assertThat(result.data().size()).isEqualTo(3);
-		assertThat(result.data().get(0).content()).contains(content);
-	}
-
 	@DisplayName("content로 질문을 페이지네이션 조회 - 실패")
 	@Test
 	void content로_질문_페이지네이션_조회_실패() {
@@ -193,27 +194,55 @@ class QuestionRepositoryImplTest extends RepositoryTest {
 
 	@Test
 	void contentToken_type() {
-		JPAQueryFactory queryFactory = new JPAQueryFactory(em);
 		QQuestion question = QQuestion.question;
-		String contentToken = "테스트 질문 예시";
+		String contentToken = "수시 입학 요강 대해";
 		QuestionType type = QuestionType.SUSI;
-
-		// List<String> results = queryFactory
-		// 	.select(question.content)
-		// 	.from(question)
-		// 	.where(question.contentToken.contains(contentToken)
-		// 		.and(question.questionType.eq(type)))
-		// 	.fetch();
-		NumberTemplate<Double> numberTemplate = Expressions.numberTemplate(Double.class,
-			"function('match', {0}, {1})", question.content, contentToken);
+		NumberTemplate<Double> numberTemplate = createBooleanTemplate(question, contentToken);
 
 		List<String> results = queryFactory.select(question.contentToken)
 			.from(question)
-			.where(
-				numberTemplate.gt(0).and(question.questionType.eq(type)))
+			.where(numberTemplate.gt(0.0).or(numberTemplate.eq(0.0)).and(question.questionType.eq(type)))
 			.fetch();
 
-		System.out.println(results);
 		assertThat(results).isNotEmpty();
+	}
+
+	@DisplayName("Full Text Search를 사용하여 content로 질문 검색 - 성공")
+	@Test
+	void fullTextSearch_content_질문_검색_성공() {
+		// given
+		QQuestion question = QQuestion.question;
+		String contentToken = "수시 입학 요강 대해";
+
+		NumberTemplate<Double> numberTemplate = createBooleanTemplate(question, contentToken);
+
+		// when
+		List<Question> results = queryFactory.selectFrom(question)
+			.where(numberTemplate.gt(0.0).or(numberTemplate.eq(0.0)))
+			.fetch();
+
+		// then
+		assertThat(results.get(0).getContentToken()).contains(contentToken);
+	}
+
+	@DisplayName("Full Text Search를 사용하여 content로 질문 검색 - 실패")
+	@Test
+	void fullTextSearch_content_질문_검색_실패() {
+		// given
+		QQuestion question = QQuestion.question;
+		String invalidContentToken = "존재하지 않는 질문";
+		NumberTemplate<Double> numberTemplate = createBooleanTemplate(question, invalidContentToken);
+
+		// when
+		List<Question> results = queryFactory.selectFrom(question)
+			.where(numberTemplate.gt(0.0))
+			.fetch();
+
+		// then
+		assertThat(results).isEmpty();
+	}
+
+	private NumberTemplate<Double> createBooleanTemplate(QQuestion question, String content) {
+		return Expressions.numberTemplate(Double.class, "function('match', {0}, {1})", question.content, content);
 	}
 }

--- a/src/test/java/mju/iphak/maru_egg/question/repository/QuestionRepositoryImplTest.java
+++ b/src/test/java/mju/iphak/maru_egg/question/repository/QuestionRepositoryImplTest.java
@@ -1,0 +1,219 @@
+package mju.iphak.maru_egg.question.repository;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberTemplate;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import mju.iphak.maru_egg.answer.domain.Answer;
+import mju.iphak.maru_egg.answer.repository.AnswerRepository;
+import mju.iphak.maru_egg.common.RepositoryTest;
+import mju.iphak.maru_egg.common.dto.pagination.SliceQuestionResponse;
+import mju.iphak.maru_egg.question.domain.QQuestion;
+import mju.iphak.maru_egg.question.domain.Question;
+import mju.iphak.maru_egg.question.domain.QuestionCategory;
+import mju.iphak.maru_egg.question.domain.QuestionType;
+import mju.iphak.maru_egg.question.dto.response.QuestionCore;
+import mju.iphak.maru_egg.question.dto.response.SearchedQuestionsResponse;
+
+class QuestionRepositoryImplTest extends RepositoryTest {
+
+	@Autowired
+	private QuestionRepositoryImpl questionRepositoryImpl;
+
+	@PersistenceContext
+	EntityManager em;
+
+	@Autowired
+	private QuestionRepository questionRepository;
+
+	@Autowired
+	private AnswerRepository answerRepository;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@Autowired
+	private JPAQueryFactory queryFactory;
+
+	private Question question;
+	private Answer answer;
+
+	@BeforeEach
+	public void setUp() throws Exception {
+		String checkIndexQuery = "SHOW INDEX FROM questions WHERE Key_name = 'idx_ft_question_content'";
+		List<?> result = jdbcTemplate.queryForList(checkIndexQuery);
+		if (!result.isEmpty()) {
+			jdbcTemplate.execute("ALTER TABLE questions DROP INDEX idx_ft_question_content");
+		}
+
+		jdbcTemplate.execute("ALTER TABLE questions ADD FULLTEXT INDEX idx_ft_question_content(content)");
+
+		jdbcTemplate.update(
+			"INSERT INTO questions (id, content, content_token, question_type, question_category, view_count) VALUES (?, ?, ?, ?, ?, ?)",
+			1L, "테스트 질문 예시 예시입니다.", "테스트 질문 예시", QuestionType.SUSI.name(), QuestionCategory.ADMISSION_GUIDELINE.name(),
+			0);
+		question = questionRepository.findById(1L).orElseThrow();
+
+		jdbcTemplate.update(
+			"INSERT INTO questions (id, content, content_token, question_type, question_category, view_count) VALUES (?, ?, ?, ?, ?, ?)",
+			2L, "추가1 테스트 질문 예시입니다.", "추가 테스트 질문 예시", QuestionType.SUSI.name(),
+			QuestionCategory.ADMISSION_GUIDELINE.name(), 0);
+		jdbcTemplate.update(
+			"INSERT INTO questions (id, content, content_token, question_type, question_category, view_count) VALUES (?, ?, ?, ?, ?, ?)",
+			3L, "추가2 테스트 질문 예시입니다.", "추가 테스트 질문 예시", QuestionType.SUSI.name(),
+			QuestionCategory.ADMISSION_GUIDELINE.name(), 0);
+		jdbcTemplate.update(
+			"INSERT INTO questions (id, content, content_token, question_type, question_category, view_count) VALUES (?, ?, ?, ?, ?, ?)",
+			4L, "추가3 테스트 질문 예시입니다.", "추가 테스트 질문 예시", QuestionType.SUSI.name(),
+			QuestionCategory.ADMISSION_GUIDELINE.name(), 0);
+		jdbcTemplate.update(
+			"INSERT INTO questions (id, content, content_token, question_type, question_category, view_count) VALUES (?, ?, ?, ?, ?, ?)",
+			5L, "추가4 테스트 질문 예시입니다.", "추가 테스트 질문 예시", QuestionType.SUSI.name(), QuestionCategory.ETC.name(), 0);
+
+		answer = Answer.of(question, "테스트 답변입니다.");
+		answerRepository.save(answer);
+	}
+
+	@DisplayName("contentToken, type으로 질문을 검색하는데 성공")
+	@Test
+	void contentToken_type_질문_검색_성공() {
+		// given
+		String contentToken = "테스트 질문 예시";
+		QuestionType type = QuestionType.SUSI;
+
+		// when
+		Optional<List<QuestionCore>> result = questionRepositoryImpl.searchQuestionsByContentTokenAndType(contentToken,
+			type);
+
+		// then
+		assertThat(result).isPresent();
+		List<QuestionCore> questionCores = result.get();
+		assertThat(questionCores).isNotEmpty();
+		assertThat(questionCores.get(0).id()).isEqualTo(question.getId());
+	}
+
+	@DisplayName("contentToken, type으로 질문을 검색하는데 실패한 경우")
+	@Test
+	void contentToken_type으로_질문_검색_실패() {
+		// given
+		String invalidContentToken = "잘못된 질문";
+		QuestionType type = QuestionType.SUSI;
+
+		// when
+		Optional<List<QuestionCore>> result = questionRepositoryImpl.searchQuestionsByContentTokenAndType(
+			invalidContentToken, type);
+
+		// then
+		assertThat(result).isPresent();
+		assertThat(result.get()).isEmpty();
+	}
+
+	@DisplayName("contentToken, type, Category로 질문을 검색하는데 성공")
+	@Test
+	void contentToken_type_Category로_질문_검색_성공() {
+		// given
+		String contentToken = "테스트 질문 예시";
+		QuestionType type = QuestionType.SUSI;
+		QuestionCategory category = QuestionCategory.ADMISSION_GUIDELINE;
+
+		// when
+		Optional<List<QuestionCore>> result = questionRepositoryImpl.searchQuestionsByContentTokenAndTypeAndCategory(
+			contentToken, type, category);
+
+		// then
+		assertThat(result).isPresent();
+		List<QuestionCore> questionCores = result.get();
+		assertThat(questionCores).isNotEmpty();
+		assertThat(questionCores.get(0).id()).isEqualTo(question.getId());
+	}
+
+	@DisplayName("contentToken, type, Category로 질문을 검색하는데 실패한 경우")
+	@Test
+	void contentToken_type_Category로_질문_검색_실패() {
+		// given
+		String invalidContentToken = "잘못된 질문";
+		QuestionType type = QuestionType.SUSI;
+		QuestionCategory category = QuestionCategory.ADMISSION_GUIDELINE;
+
+		// when
+		Optional<List<QuestionCore>> result = questionRepositoryImpl.searchQuestionsByContentTokenAndTypeAndCategory(
+			invalidContentToken, type, category);
+
+		// then
+		assertThat(result).isPresent();
+		assertThat(result.get()).isEmpty();
+	}
+
+	@DisplayName("content로 질문을 페이지네이션 조회 - 성공")
+	@Test
+	void content로_질문_페이지네이션_조회_성공() {
+		// given
+		String content = "테스트 질문 예시";
+		Pageable pageable = PageRequest.of(0, 3);
+
+		// when
+		SliceQuestionResponse<SearchedQuestionsResponse> result = questionRepositoryImpl.searchQuestionsOfCursorPagingByContent(
+			content, null, null, pageable);
+
+		// then
+		assertThat(result.data()).isNotEmpty();
+		assertThat(result.data().size()).isEqualTo(3);
+		assertThat(result.data().get(0).content()).contains(content);
+	}
+
+	@DisplayName("content로 질문을 페이지네이션 조회 - 실패")
+	@Test
+	void content로_질문_페이지네이션_조회_실패() {
+		// given
+		String content = "존재하지 않는 질문";
+		Pageable pageable = PageRequest.of(0, 3);
+
+		// when
+		SliceQuestionResponse<SearchedQuestionsResponse> result = questionRepositoryImpl.searchQuestionsOfCursorPagingByContent(
+			content, null, null, pageable);
+
+		// then
+		assertThat(result.data()).isEmpty();
+	}
+
+	@Test
+	void contentToken_type() {
+		JPAQueryFactory queryFactory = new JPAQueryFactory(em);
+		QQuestion question = QQuestion.question;
+		String contentToken = "테스트 질문 예시";
+		QuestionType type = QuestionType.SUSI;
+
+		// List<String> results = queryFactory
+		// 	.select(question.content)
+		// 	.from(question)
+		// 	.where(question.contentToken.contains(contentToken)
+		// 		.and(question.questionType.eq(type)))
+		// 	.fetch();
+		NumberTemplate<Double> numberTemplate = Expressions.numberTemplate(Double.class,
+			"function('match', {0}, {1})", question.content, contentToken);
+
+		List<String> results = queryFactory.select(question.contentToken)
+			.from(question)
+			.where(
+				numberTemplate.gt(0).and(question.questionType.eq(type)))
+			.fetch();
+
+		System.out.println(results);
+		assertThat(results).isNotEmpty();
+	}
+}

--- a/src/test/java/mju/iphak/maru_egg/question/repository/QuestionRepositoryTest.java
+++ b/src/test/java/mju/iphak/maru_egg/question/repository/QuestionRepositoryTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
 
 import mju.iphak.maru_egg.answer.domain.Answer;
 import mju.iphak.maru_egg.answer.repository.AnswerRepository;
@@ -24,20 +25,37 @@ class QuestionRepositoryTest extends RepositoryTest {
 	@Autowired
 	private AnswerRepository answerRepository;
 
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
 	private Question question;
 	private Answer answer;
 
 	@BeforeEach
 	public void setUp() throws Exception {
+		jdbcTemplate.execute("ALTER TABLE questions ADD FULLTEXT INDEX idx_ft_question_content(content)");
+
 		question = new Question("테스트 질문입니다.", "테스트 질문", QuestionType.SUSI,
 			QuestionCategory.ADMISSION_GUIDELINE, 0);
 		questionRepository.save(question);
+		Question additionalQuestion1 = Question.of("추가1 테스트 질문입니다.", "추가 테스트 질문", QuestionType.SUSI,
+			QuestionCategory.ADMISSION_GUIDELINE);
+		questionRepository.save(additionalQuestion1);
+		Question additionalQuestion2 = Question.of("추가2 테스트 질문입니다.", "추가 테스트 질문", QuestionType.SUSI,
+			QuestionCategory.ADMISSION_GUIDELINE);
+		questionRepository.save(additionalQuestion2);
+		Question additionalQuestion3 = Question.of("추가3 테스트 질문입니다.", "추가 테스트 질문", QuestionType.SUSI,
+			QuestionCategory.ADMISSION_GUIDELINE);
+		questionRepository.save(additionalQuestion3);
+		Question additionalQuestion4 = Question.of("추가4 테스트 질문입니다.", "추가 테스트 질문", QuestionType.SUSI,
+			QuestionCategory.ADMISSION_GUIDELINE);
+		questionRepository.save(additionalQuestion4);
 
 		answer = Answer.of(question, "테스트 답변입니다.");
 		answerRepository.save(answer);
 	}
 
-	@DisplayName("질문을 조회하는데 설공")
+	@DisplayName("질문을 조회하는데 성공")
 	@Test
 	void 질문_조회_성공() {
 		// given
@@ -45,15 +63,14 @@ class QuestionRepositoryTest extends RepositoryTest {
 		QuestionCategory category = QuestionCategory.ADMISSION_GUIDELINE;
 
 		// when
-		List<Question> questions = questionRepository.findAllByQuestionTypeAndQuestionCategory(
-			type, category);
+		List<Question> questions = questionRepository.findAllByQuestionTypeAndQuestionCategory(type, category);
 
 		// then
 		assertThat(questions).isNotEmpty();
 		assertThat(questions).isEqualTo(List.of(question));
 	}
 
-	@DisplayName("질문을 조회하는데 실패한 경우-type, category 를 못 찾은 경우")
+	@DisplayName("질문을 조회하는데 실패한 경우 - type, category를 못 찾은 경우")
 	@Test
 	void 질문_조회_실패() {
 		// given
@@ -61,8 +78,7 @@ class QuestionRepositoryTest extends RepositoryTest {
 		QuestionCategory category = QuestionCategory.ADMISSION_GUIDELINE;
 
 		// when
-		List<Question> questions = questionRepository.findAllByQuestionTypeAndQuestionCategory(
-			invalidType, category);
+		List<Question> questions = questionRepository.findAllByQuestionTypeAndQuestionCategory(invalidType, category);
 
 		// then
 		assertThat(questions.isEmpty()).isTrue();

--- a/src/test/java/mju/iphak/maru_egg/question/repository/QuestionRepositoryTest.java
+++ b/src/test/java/mju/iphak/maru_egg/question/repository/QuestionRepositoryTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.jdbc.core.JdbcTemplate;
 
 import mju.iphak.maru_egg.answer.domain.Answer;
 import mju.iphak.maru_egg.answer.repository.AnswerRepository;
@@ -25,31 +24,26 @@ class QuestionRepositoryTest extends RepositoryTest {
 	@Autowired
 	private AnswerRepository answerRepository;
 
-	@Autowired
-	private JdbcTemplate jdbcTemplate;
-
 	private Question question;
 	private Answer answer;
 
 	@BeforeEach
 	public void setUp() throws Exception {
-		jdbcTemplate.execute("ALTER TABLE questions ADD FULLTEXT INDEX idx_ft_question_content(content)");
-
-		question = new Question("테스트 질문입니다.", "테스트 질문", QuestionType.SUSI,
+		question = new Question("테스트 질문 예시 예시입니다.", "테스트 질문 예시", QuestionType.SUSI,
 			QuestionCategory.ADMISSION_GUIDELINE, 0);
 		questionRepository.save(question);
-		Question additionalQuestion1 = Question.of("추가1 테스트 질문입니다.", "추가 테스트 질문", QuestionType.SUSI,
+		Question additionalQuestion1 = Question.of("추가1 테스트 질문 예시입니다.", "추가 테스트 질문 예시", QuestionType.SUSI,
 			QuestionCategory.ADMISSION_GUIDELINE);
 		questionRepository.save(additionalQuestion1);
-		Question additionalQuestion2 = Question.of("추가2 테스트 질문입니다.", "추가 테스트 질문", QuestionType.SUSI,
+		Question additionalQuestion2 = Question.of("추가2 테스트 질문 예시입니다.", "추가 테스트 질문 예시", QuestionType.SUSI,
 			QuestionCategory.ADMISSION_GUIDELINE);
 		questionRepository.save(additionalQuestion2);
-		Question additionalQuestion3 = Question.of("추가3 테스트 질문입니다.", "추가 테스트 질문", QuestionType.SUSI,
+		Question additionalQuestion3 = Question.of("추가3 테스트 질문 예시입니다.", "추가 테스트 질문 예시", QuestionType.SUSI,
 			QuestionCategory.ADMISSION_GUIDELINE);
 		questionRepository.save(additionalQuestion3);
-		Question additionalQuestion4 = Question.of("추가4 테스트 질문입니다.", "추가 테스트 질문", QuestionType.SUSI,
-			QuestionCategory.ADMISSION_GUIDELINE);
-		questionRepository.save(additionalQuestion4);
+		Question additionalQuestionETC = Question.of("추가4 테스트 질문 예시입니다.", "추가 테스트 질문 예시", QuestionType.SUSI,
+			QuestionCategory.ETC);
+		questionRepository.save(additionalQuestionETC);
 
 		answer = Answer.of(question, "테스트 답변입니다.");
 		answerRepository.save(answer);
@@ -67,7 +61,8 @@ class QuestionRepositoryTest extends RepositoryTest {
 
 		// then
 		assertThat(questions).isNotEmpty();
-		assertThat(questions).isEqualTo(List.of(question));
+		assertThat(questions.size()).isEqualTo(4);
+		assertThat(questions.get(0)).isEqualTo(question);
 	}
 
 	@DisplayName("질문을 조회하는데 실패한 경우 - type, category를 못 찾은 경우")
@@ -95,7 +90,8 @@ class QuestionRepositoryTest extends RepositoryTest {
 
 		// then
 		assertThat(questions).isNotEmpty();
-		assertThat(questions).isEqualTo(List.of(question));
+		assertThat(questions.size()).isEqualTo(5);
+		assertThat(questions.get(0)).isEqualTo(question);
 	}
 
 	@DisplayName("질문을 조회하는데 실패한 경우 - type만으로 조회할 때")


### PR DESCRIPTION
## ✅ 작업 내용
1. QuestionRepositoryImpl 클래스 수정

	•	QuestionRepositoryImpl 클래스는 QueryDSL을 사용하여 데이터베이스 쿼리를 실행합니다.
	•	주요 기능은 searchQuestionsOfCursorPagingByContent 메서드를 통해 페이징된 질문 목록을 검색하는 것입니다.

2. searchQuestionsOfCursorPagingByContent 메서드 구현

	•	이 메서드는 검색어와 페이지네이션 커서를 사용하여 질문 목록을 검색합니다.
	•	커서 기반 페이지네이션을 구현하기 위해 cursorViewCount와 questionId를 사용합니다.
	•	이 값들이 null이거나 0일 경우 최대 값(Integer.MAX_VALUE 및 Long.MAX_VALUE)을 사용하여 처음 페이지를 가져오도록 설정합니다.
	•	BooleanExpression을 사용하여 페이징 커서 조건을 만듭니다.
	•	쿼리를 실행하여 질문 목록을 가져오고, hasNext 플래그를 설정하여 다음 페이지가 있는지 확인합니다.
	•	마지막 질문의 viewCount와 id를 사용하여 다음 커서를 설정합니다.

3. SliceQuestionResponse 클래스 생성

	•	SliceQuestionResponse 클래스는 커서 기반 페이지네이션을 지원하기 위해 확장된 슬라이스 응답 클래스입니다.
	•	기본 SliceResponse 클래스를 확장하여 nextCursorViewCount와 nextQuestionId 필드를 추가합니다.

4. 쿼리 메서드 분리 및 리팩토링

	•	createBooleanTemplate 메서드: 검색어에 대한 Boolean 템플릿을 생성합니다.
	•	createCursorPredicate 메서드: 커서 조건을 생성합니다.
	•	fetchQuestions 메서드: 쿼리를 실행하여 질문 목록을 가져옵니다.
	•	mapToResponse 메서드: 질문 엔티티를 DTO로 변환합니다.

## 🤔 고민했던 점과 해결 방법
1.	커서 기반 페이지네이션 구현:
	•	커서 기반 페이지네이션을 구현하기 위해 cursorViewCount와 questionId를 사용해야 했습니다.
	•	처음 페이지를 가져올 때는 이 값들이 null 또는 0일 수 있으므로, 이를 최대 값으로 설정하여 처음 페이지를 가져오도록 했습니다.
	2.	커서 조건 생성:
	•	커서 조건을 생성할 때 viewCount와 questionId를 조합하여 정확한 페이지네이션을 구현해야 했습니다.
	•	동일한 viewCount를 가진 질문들 사이에서 중복되지 않도록 id를 추가 조건으로 사용했습니다.
	3.	응답 포맷 확장:
	•	기본 슬라이스 응답을 확장하여 커서 값을 포함하도록 했습니다.
	•	이를 통해 클라이언트가 다음 페이지를 요청할 때 필요한 커서 값을 쉽게 전달할 수 있게 했습니다.
	4.	쿼리 최적화:
	•	fetchQuestions 메서드에서 필요한 데이터만 가져오도록 쿼리를 최적화했습니다.
	•	pageSize + 1을 가져와서 hasNext 플래그를 설정하고, 필요시 마지막 요소를 제거했습니다.

## 🔊 도움이 필요한 부분
- MySQL full text search의 test에서 match 함수가 적절하게 작동하지 않습니다. (match point가 0.0으로만 됨)
- 배포 환경과 Local 환경은 문제가 없는 것을 확인한 상태입니다. 추후에 더 면밀히 확인 후 고쳐두겠습니다. 