### PR TITLE
[test] auth test 추가 및 통합 test와 단위 test 환경 분리

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -22,30 +22,21 @@ jobs:
           java-version: 17
           distribution: 'temurin'
 
-      # 환경별 yml 파일 생성
-      - name: make application.yml
+      # 환경별 yml 파일 생성 - 개발 환경
+      - name: make application.yml for develop
         if: contains(github.ref, 'develop')
         run: |
           cd ./src/main/resources
           touch ./application.yml
-          echo "${{ secrets.YML }}" > ./application.yml
+          echo "${{ secrets.YML_DEV }}" > ./application.yml
         shell: bash
 
-      # 환경별 yml 파일 생성 - dev
-      - name: make application-dev.yml
-        if: contains(github.ref, 'develop')
-        run: |
-          cd ./src/main/resources
-          touch ./application-dev.yml
-          echo "${{ secrets.YML_DEV }}" > ./application-dev.yml
-        shell: bash
-
-      # 환경별 yml 파일 생성 - test
-      - name: make application-test.yml
+      # 환경별 yml 파일 생성 - 통합 테스트
+      - name: make application-integration-test.yml
         run: |
           cd ./src/test/resources
-          touch ./application-test.yml
-          echo "${{ secrets.YML_TEST }}" > ./application-test.yml
+          touch ./application-integration-test.yml
+          echo "${{ secrets.YML_INTEGRATION_TEST }}" > ./application-integration-test.yml
         shell: bash
 
       # Gradle 패키지 캐시
@@ -65,9 +56,13 @@ jobs:
         with:
           arguments: clean bootJar
 
-      # Gradle로 테스트
-      - name: Test with Gradle
+      # Gradle로 단위 테스트 실행
+      - name: Unit Test with Gradle
         run: ./gradlew test --no-daemon
+
+      # Gradle로 통합 테스트 실행
+      - name: Integration Test with Gradle
+        run: ./gradlew integrationTest --no-daemon
 
       # Docker Hub에 로그인
       - name: Log in to Docker Hub

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -40,6 +40,14 @@ jobs:
           echo "${{ secrets.YML_DEV }}" > ./application-dev.yml
         shell: bash
 
+      # 환경별 yml 파일 생성 - test
+      - name: make application-test.yml
+        run: |
+          cd ./src/test/resources
+          touch ./application-test.yml
+          echo "${{ secrets.YML_TEST }}" > ./application-test.yml
+        shell: bash
+
       # Gradle 패키지 캐시
       - name: Cache Gradle packages
         uses: actions/cache@v3

--- a/src/main/java/mju/iphak/maru_egg/question/application/QuestionService.java
+++ b/src/main/java/mju/iphak/maru_egg/question/application/QuestionService.java
@@ -31,7 +31,7 @@ public class QuestionService {
 	private final AnswerService answerService;
 
 	public List<QuestionResponse> getQuestions(final QuestionType type, final QuestionCategory category) {
-		List<Question> questions = findQuestionsByTypeAndCategory(type, category);
+		List<Question> questions = findQuestions(type, category);
 		return questions.stream()
 			.map(question -> createQuestionResponse(question, answerService.getAnswerByQuestionId(question.getId())))
 			.collect(Collectors.toList());
@@ -45,7 +45,7 @@ public class QuestionService {
 			cursorViewCount, questionId, pageable);
 	}
 
-	private List<Question> findQuestionsByTypeAndCategory(final QuestionType type, final QuestionCategory category) {
+	private List<Question> findQuestions(final QuestionType type, final QuestionCategory category) {
 		if (category == null) {
 			return questionRepository.findAllByQuestionType(type);
 		}

--- a/src/main/resources/application-integration-test.yml
+++ b/src/main/resources/application-integration-test.yml
@@ -18,10 +18,10 @@ spring:
     password: test
 
 web-client:
-  base-url: http://localhost:8080
+  base-url: ${LLM_BASE_URL}
 
 jwt:
-  secretKey: my_test_secret_key
+  secretKey: ${JWT_SECRET}
 
   access:
     expiration: 3600000 # 1시간(60분) (1000L(ms -> s) * 60L(s -> m) * 60L(m -> h))

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -20,6 +20,17 @@ spring:
 web-client:
   base-url: ${LLM_BASE_URL}
 
+jwt:
+  secretKey: ${JWT_SECRET}
+
+  access:
+    expiration: 3600000 # 1시간(60분) (1000L(ms -> s) * 60L(s -> m) * 60L(m -> h))
+    header: "Authorization"
+
+  refresh:
+    expiration: 1209600000 #  (1000L(ms -> s) * 60L(s -> m) * 60L(m -> h) * 24L(h -> 하루) * 14(2주))
+    header: "Authorization-refresh"
+
 logging:
   level:
     org:

--- a/src/test/java/mju/iphak/maru_egg/MaruEggApplicationTests.java
+++ b/src/test/java/mju/iphak/maru_egg/MaruEggApplicationTests.java
@@ -4,7 +4,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 
 import mju.iphak.maru_egg.common.config.QueryDslConfig;
 import mju.iphak.maru_egg.common.config.SecurityConfig;
@@ -13,10 +12,6 @@ import mju.iphak.maru_egg.common.config.WebClientConfig;
 @Import({TestcontainersConfiguration.class, QueryDslConfig.class, WebClientConfig.class, SecurityConfig.class})
 @SpringBootTest
 @ActiveProfiles("test")
-@TestPropertySource(properties = {
-	"web-client.base-url=http://localhost:8080",
-	"JWT_SECRET=my_test_secret_key"
-})
 class MaruEggApplicationTests {
 
 	@Test

--- a/src/test/java/mju/iphak/maru_egg/auth/api/AuthControllerTest.java
+++ b/src/test/java/mju/iphak/maru_egg/auth/api/AuthControllerTest.java
@@ -1,0 +1,66 @@
+package mju.iphak.maru_egg.auth.api;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import mju.iphak.maru_egg.auth.application.AuthService;
+import mju.iphak.maru_egg.auth.dto.request.SignUpRequest;
+import mju.iphak.maru_egg.common.IntegrationTest;
+import mju.iphak.maru_egg.user.domain.User;
+import mju.iphak.maru_egg.user.repository.UserRepository;
+
+class AuthControllerTest extends IntegrationTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@InjectMocks
+	private AuthController authController;
+
+	@MockBean
+	private AuthService authService;
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Autowired
+	private PasswordEncoder passwordEncoder;
+
+	private User user;
+
+	@BeforeEach
+	void setUp() {
+		// 유저 데이터 설정
+		user = User.of("testuser@example.com", passwordEncoder.encode("Password123!"));
+		userRepository.save(user);
+	}
+
+	@Test
+	void testSignUp() throws Exception {
+		// given
+		SignUpRequest signUpRequest = new SignUpRequest("testuser2@example.com", "Password123!");
+
+		// when & then
+		mockMvc.perform(post("/api/auth/sign-up")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(signUpRequest)))
+			.andExpect(status().isOk());
+
+		verify(authService, times(1)).signUp(signUpRequest.email(), signUpRequest.password());
+	}
+}

--- a/src/test/java/mju/iphak/maru_egg/common/IntegrationTest.java
+++ b/src/test/java/mju/iphak/maru_egg/common/IntegrationTest.java
@@ -1,12 +1,12 @@
 package mju.iphak.maru_egg.common;
 
+import org.junit.Ignore;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -20,14 +20,11 @@ import mju.iphak.maru_egg.common.config.WebClientConfig;
 
 @Import({TestcontainersConfiguration.class, QueryDslConfig.class, WebClientConfig.class, SecurityConfig.class})
 @RunWith(SpringRunner.class)
-@SpringBootTest()
+@SpringBootTest
 @AutoConfigureMockMvc
 @Transactional
-@ActiveProfiles("test")
-@TestPropertySource(properties = {
-	"web-client.base-url=http://localhost:8080",
-	"JWT_SECRET=my_test_secret_key"
-})
+@ActiveProfiles("integration-test")
+@Ignore
 public class IntegrationTest {
 	@Autowired
 	protected MockMvc mvc;

--- a/src/test/java/mju/iphak/maru_egg/common/IntegrationTest.java
+++ b/src/test/java/mju/iphak/maru_egg/common/IntegrationTest.java
@@ -6,6 +6,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -23,6 +24,10 @@ import mju.iphak.maru_egg.common.config.WebClientConfig;
 @AutoConfigureMockMvc
 @Transactional
 @ActiveProfiles("test")
+@TestPropertySource(properties = {
+	"web-client.base-url=http://localhost:8080",
+	"JWT_SECRET=my_test_secret_key"
+})
 public class IntegrationTest {
 	@Autowired
 	protected MockMvc mvc;

--- a/src/test/java/mju/iphak/maru_egg/common/MockTest.java
+++ b/src/test/java/mju/iphak/maru_egg/common/MockTest.java
@@ -1,5 +1,6 @@
 package mju.iphak.maru_egg.common;
 
+import org.junit.Ignore;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -14,8 +15,9 @@ import mju.iphak.maru_egg.TestcontainersConfiguration;
 @ActiveProfiles("test")
 @RunWith(MockitoJUnitRunner.class)
 @TestPropertySource(properties = {
-	"web-client.base-url=http://localhost:8080",
-	"JWT_SECRET=my_test_secret_key"
+	"web-client.base-url-test=http://localhost:8080",
+	"jwt.secretKey-test=my_test_secret_key"
 })
+@Ignore
 public class MockTest {
 }

--- a/src/test/java/mju/iphak/maru_egg/common/MockTest.java
+++ b/src/test/java/mju/iphak/maru_egg/common/MockTest.java
@@ -5,6 +5,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 
 import mju.iphak.maru_egg.TestcontainersConfiguration;
 
@@ -12,5 +13,9 @@ import mju.iphak.maru_egg.TestcontainersConfiguration;
 @SpringBootTest
 @ActiveProfiles("test")
 @RunWith(MockitoJUnitRunner.class)
+@TestPropertySource(properties = {
+	"web-client.base-url=http://localhost:8080",
+	"JWT_SECRET=my_test_secret_key"
+})
 public class MockTest {
 }

--- a/src/test/java/mju/iphak/maru_egg/common/RepositoryTest.java
+++ b/src/test/java/mju/iphak/maru_egg/common/RepositoryTest.java
@@ -1,5 +1,6 @@
 package mju.iphak.maru_egg.common;
 
+import org.junit.Ignore;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -15,5 +16,6 @@ import mju.iphak.maru_egg.common.config.QueryDslConfig;
 @DataJpaTest
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Ignore
 public class RepositoryTest {
 }

--- a/src/test/java/mju/iphak/maru_egg/question/api/QuestionControllerTest.java
+++ b/src/test/java/mju/iphak/maru_egg/question/api/QuestionControllerTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.ResultActions;
 
 import mju.iphak.maru_egg.answer.domain.Answer;
@@ -29,10 +28,6 @@ import mju.iphak.maru_egg.question.dto.request.SearchQuestionsRequest;
 import mju.iphak.maru_egg.question.dto.response.QuestionResponse;
 import mju.iphak.maru_egg.question.dto.response.SearchedQuestionsResponse;
 
-@TestPropertySource(properties = {
-	"web-client.base-url=http://localhost:8080",
-	"JWT_SECRET=my_test_secret_key"
-})
 class QuestionControllerTest extends IntegrationTest {
 
 	@MockBean

--- a/src/test/java/mju/iphak/maru_egg/question/api/QuestionControllerTest.java
+++ b/src/test/java/mju/iphak/maru_egg/question/api/QuestionControllerTest.java
@@ -1,5 +1,6 @@
 package mju.iphak.maru_egg.question.api;
 
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
@@ -9,12 +10,21 @@ import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+import org.springframework.web.reactive.function.client.WebClient;
 
+import mju.iphak.maru_egg.answer.application.AnswerService;
 import mju.iphak.maru_egg.answer.domain.Answer;
 import mju.iphak.maru_egg.answer.dto.response.AnswerResponse;
+import mju.iphak.maru_egg.answer.repository.AnswerRepository;
 import mju.iphak.maru_egg.common.IntegrationTest;
 import mju.iphak.maru_egg.common.dto.pagination.SliceQuestionResponse;
 import mju.iphak.maru_egg.question.application.QuestionProcessingService;
@@ -27,65 +37,97 @@ import mju.iphak.maru_egg.question.dto.request.QuestionRequest;
 import mju.iphak.maru_egg.question.dto.request.SearchQuestionsRequest;
 import mju.iphak.maru_egg.question.dto.response.QuestionResponse;
 import mju.iphak.maru_egg.question.dto.response.SearchedQuestionsResponse;
+import mju.iphak.maru_egg.question.repository.QuestionRepository;
+import reactor.core.publisher.Mono;
 
 class QuestionControllerTest extends IntegrationTest {
 
-	@MockBean
+	@Autowired
 	private QuestionProcessingService questionProcessingService;
 
-	@MockBean
+	@Autowired
 	private QuestionService questionService;
+
+	@Autowired
+	private QuestionRepository questionRepository;
+
+	@Autowired
+	private AnswerRepository answerRepository;
+
+	@Autowired
+	private AnswerService answerService;
 
 	private Question question;
 	private Answer answer;
 	private QuestionType type;
 	private QuestionCategory category;
 	private String content;
-	private String contentToken;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@Mock
+	private ExchangeFunction exchangeFunction;
+
+	@Value("${web-client.base-url}")
+	private String llmBaseUrl;
 
 	@BeforeEach
 	void setUp() {
+		String checkIndexQuery = "SHOW INDEX FROM questions WHERE Key_name = 'idx_ft_question_content'";
+		List<?> result = jdbcTemplate.queryForList(checkIndexQuery);
+		if (!result.isEmpty()) {
+			jdbcTemplate.execute("ALTER TABLE questions DROP INDEX idx_ft_question_content");
+		}
+		jdbcTemplate.execute("ALTER TABLE questions ADD FULLTEXT INDEX idx_ft_question_content(content)");
 		type = QuestionType.SUSI;
 		category = QuestionCategory.ADMISSION_GUIDELINE;
-		content = "content";
-		contentToken = "content";
-		question = Question.of(content, contentToken, type, category);
-		answer = Answer.of(question, content);
+		content = "수시 일정 알려주세요.";
+		question = questionRepository.save(Question.of("수시 일정 알려주세요.", "수시 일정", QuestionType.SUSI,
+			QuestionCategory.ADMISSION_GUIDELINE));
+		answer = answerRepository.save(Answer.of(question,
+			"수시 일정은 2024년 12월 19일(목)부터 2024년 12월 26일(목) 18:00까지 최초합격자 발표가 있고, 2025년 2월 10일(월) 10:00부터 2025년 2월 12일(수) 15:00까지 문서등록 및 등록금 납부가 진행됩니다. 등록금 납부 기간은 2024년 12월 16일(월) 10:00부터 2024년 12월 18일(수) 15:00까지이며, 방법은 입학처 홈페이지를 통한 문서등록 및 등록금 납부를 하시면 됩니다. 상세 안내는 추후 입학처 홈페이지를 통해 공지될 예정입니다."));
+
+		WebClient webClient = WebClient.builder()
+			.exchangeFunction(exchangeFunction)
+			.baseUrl(llmBaseUrl)
+			.build();
+
+		answerService = new AnswerService(answerRepository, webClient);
+
+		ClientResponse clientResponse = ClientResponse.create(HttpStatusCode.valueOf(200))
+			.header("Content-Type", "application/json")
+			.body("{\"answer\":\"" + answer.getContent() + "\"}")
+			.build();
+
+		when(exchangeFunction.exchange(any())).thenReturn(Mono.just(clientResponse));
 	}
 
 	@Test
 	void 질문_API() throws Exception {
 		// given
+		QuestionRequest request = new QuestionRequest(type, category, content);
 		AnswerResponse answerResponse = AnswerResponse.from(answer);
 
-		QuestionRequest request = new QuestionRequest(type, category, content);
-		QuestionResponse response = QuestionResponse.of(question, answerResponse);
-
 		// when
-		when(questionProcessingService.question(type, category, content)).thenReturn(response);
 		ResultActions resultActions = requestCreateQuestion(request);
 
 		// then
 		resultActions
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.id").value(question.getId()))
-			.andExpect(jsonPath("$.dateInformation").value(question.getDateInformation()))
-			.andExpect(jsonPath("$.answer.id").value(answerResponse.id()))
-			.andExpect(jsonPath("$.answer.content").value(answerResponse.content()))
-			.andExpect(jsonPath("$.answer.renewalYear").value(answerResponse.renewalYear()))
-			.andExpect(jsonPath("$.answer.dateInformation").value(answerResponse.dateInformation()));
+			.andExpect(jsonPath("$.content").value(question.getContent()))
+			.andExpect(jsonPath("$.answer.content").isNotEmpty())
+			.andExpect(jsonPath("$.answer.renewalYear").value(answerResponse.renewalYear()));
 	}
 
 	@Test
 	void 질문_목록_조회_API() throws Exception {
 		// given
 		AnswerResponse answerResponse = AnswerResponse.from(answer);
-
 		FindQuestionsRequest request = new FindQuestionsRequest(type, category);
-		QuestionResponse response = QuestionResponse.of(question, answerResponse);
 
+		System.out.println(questionRepository.findAll().get(0).getQuestionType());
 		// when
-		when(questionService.getQuestions(type, category)).thenReturn(List.of(response));
 		ResultActions resultActions = requestFindQuestions(request);
 
 		// then
@@ -105,7 +147,6 @@ class QuestionControllerTest extends IntegrationTest {
 		QuestionResponse response = QuestionResponse.of(question, answerResponse);
 
 		// when
-		when(questionService.getQuestions(type, null)).thenReturn(List.of(response));
 		ResultActions resultActions = requestFindQuestionsWithoutCategory(request);
 
 		// then
@@ -125,16 +166,12 @@ class QuestionControllerTest extends IntegrationTest {
 			List.of(searchedQuestionsResponse), 0, 5, false, null, null);
 
 		// when
-		when(questionService.searchQuestionsOfCursorPaging(request.content(), request.cursorViewCount(),
-			request.questionId(), request.size()))
-			.thenReturn(response);
 		ResultActions resultActions = requestSearchQuestions(request);
 
 		// then
 		resultActions
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.data[0].content").value("example content"))
-			.andExpect(jsonPath("$.hasNext").value(false));
+			.andExpect(jsonPath("$.data").isArray());
 	}
 
 	private ResultActions requestCreateQuestion(QuestionRequest dto) throws Exception {

--- a/src/test/java/mju/iphak/maru_egg/question/application/QuestionProcessingServiceTest.java
+++ b/src/test/java/mju/iphak/maru_egg/question/application/QuestionProcessingServiceTest.java
@@ -20,7 +20,6 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.reactive.ClientHttpConnector;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -45,10 +44,6 @@ import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import reactor.core.publisher.Mono;
 
-@TestPropertySource(properties = {
-	"web-client.base-url=http://localhost:8080",
-	"JWT_SECRET=my_test_secret_key"
-})
 class QuestionProcessingServiceTest extends MockTest {
 
 	@Mock

--- a/src/test/java/mju/iphak/maru_egg/question/application/QuestionServiceTest.java
+++ b/src/test/java/mju/iphak/maru_egg/question/application/QuestionServiceTest.java
@@ -21,7 +21,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.reactive.ClientHttpConnector;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -46,10 +45,6 @@ import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import reactor.core.publisher.Mono;
 
-@TestPropertySource(properties = {
-	"web-client.base-url=http://localhost:8080",
-	"JWT_SECRET=my_test_secret_key"
-})
 class QuestionServiceTest extends MockTest {
 
 	@Mock


### PR DESCRIPTION
## ✅ 작업 내용
- 통합 test에서 mock으로 진행되었던 db까지의 연결을 모두 실제 환경으로 변경했습니다.
- auth 통합 test를 추가했습니다.
- application-test에서는 unit test 에 대해서 관리하게 됩니다.
- application-integration-test는 실제 llm 서버와 연결하여 진행하는 통합 test를 관리합니다.
- 이에 맞도록 ci-cd도 변경했습니다.

## 🤔 고민 했던 부분
- application-test에서 변수명으로만 분리하려 했으나, 통합 테스트와 단위 테스트를 확실히 분리하고 mock과 실제 환경의 차이를 두기 위해 설정 파일도 따로 관리하고자 했습니다.
- 좋은 방법은 아니라는 생각이 들기에 동일한 부분은 application-test로 통합은 application-integration-test로 단위 test는 application-unit-test로 변경할지 고민 중입니다.
