### PR TITLE
[refactor] webClient exception 추가로 예외처리

### DIFF
--- a/src/main/java/mju/iphak/maru_egg/answer/application/AnswerService.java
+++ b/src/main/java/mju/iphak/maru_egg/answer/application/AnswerService.java
@@ -2,6 +2,7 @@ package mju.iphak.maru_egg.answer.application;
 
 import static mju.iphak.maru_egg.common.exception.ErrorCode.*;
 
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,6 +17,9 @@ import mju.iphak.maru_egg.answer.domain.Answer;
 import mju.iphak.maru_egg.answer.dto.request.LLMAskQuestionRequest;
 import mju.iphak.maru_egg.answer.dto.response.LLMAnswerResponse;
 import mju.iphak.maru_egg.answer.repository.AnswerRepository;
+import mju.iphak.maru_egg.common.exception.custom.webClient.BadRequestWebClientException;
+import mju.iphak.maru_egg.common.exception.custom.webClient.InternalServerErrorWebClientException;
+import mju.iphak.maru_egg.common.exception.custom.webClient.NotFoundWebClientException;
 import reactor.core.publisher.Mono;
 
 @RequiredArgsConstructor
@@ -44,6 +48,22 @@ public class AnswerService {
 			.contentType(MediaType.APPLICATION_FORM_URLENCODED)
 			.body(BodyInserters.fromFormData(formData))
 			.retrieve()
+			.onStatus(
+				HttpStatusCode::isError,
+				response -> {
+					return switch (response.statusCode().value()) {
+						case 400 -> Mono.error(
+							new BadRequestWebClientException(
+								String.format(BAD_REQUEST_WEBCLIENT.getMessage(), "LLM 서버", request.questionType(),
+									request.questionCategory(), request.question())));
+						case 404 -> Mono.error(
+							new NotFoundWebClientException(String.format(NOT_FOUND_WEBCLIENT.getMessage(), "LLM 서버")));
+						default -> Mono.error(
+							new InternalServerErrorWebClientException(
+								String.format(INTERNAL_ERROR_WEBCLIENT.getMessage(), "LLM 서버")));
+					};
+				}
+			)
 			.bodyToMono(LLMAnswerResponse.class);
 	}
 

--- a/src/main/java/mju/iphak/maru_egg/common/exception/ErrorCode.java
+++ b/src/main/java/mju/iphak/maru_egg/common/exception/ErrorCode.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 public enum ErrorCode {
 
 	// 400 error
+	BAD_REQUEST_WEBCLIENT(BAD_REQUEST, "%s에 잘못된 요청을 보냈습니다. (questionType: %s, questionCategory: %s, question: %s"),
 
 	// 401 error
 	UNAUTHORIZED_REQUEST(UNAUTHORIZED, "로그인 후 다시 시도해주세요."),
@@ -24,9 +25,11 @@ public enum ErrorCode {
 	NOT_FOUND_ANSWER(NOT_FOUND, "답변 id가 %s인 답변을 찾을 수 없습니다."),
 	NOT_FOUND_ANSWER_BY_QUESTION_ID(NOT_FOUND, "질문 id가 %s인 답변을 찾을 수 없습니다."),
 	NOT_FOUND_USER(NOT_FOUND, "유저 이메일이 %s인 유저를 찾을 수 없습니다."),
+	NOT_FOUND_WEBCLIENT(NOT_FOUND, "%s에서 값을 불러오지 못 했습니다."),
 
 	// 500 error
-	INTERNAL_ERROR_SIMILARITY(NOT_FOUND, "contentToken: %s, question: %s인 질문의 유사도를 검사하는 도중 오류가 발생했습니다.");
+	INTERNAL_ERROR_SIMILARITY(INTERNAL_SERVER_ERROR, "contentToken: %s, question: %s인 질문의 유사도를 검사하는 도중 오류가 발생했습니다."),
+	INTERNAL_ERROR_WEBCLIENT(INTERNAL_SERVER_ERROR, "%s에서 서버 오류가 발생했습니다.");
 
 	private final HttpStatus status;
 	private final String message;

--- a/src/main/java/mju/iphak/maru_egg/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/mju/iphak/maru_egg/common/exception/GlobalExceptionHandler.java
@@ -14,6 +14,9 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import jakarta.persistence.EntityNotFoundException;
 import lombok.extern.slf4j.Slf4j;
+import mju.iphak.maru_egg.common.exception.custom.webClient.BadRequestWebClientException;
+import mju.iphak.maru_egg.common.exception.custom.webClient.InternalServerErrorWebClientException;
+import mju.iphak.maru_egg.common.exception.custom.webClient.NotFoundWebClientException;
 
 @Slf4j
 @RestControllerAdvice
@@ -61,6 +64,31 @@ public class GlobalExceptionHandler {
 		log.error(LOG_FORMAT, timestamp, e.getClass().getSimpleName(), e.getMessage());
 		return ResponseEntity.status(NOT_FOUND)
 			.body(ErrorResponse.of(e.getClass().getSimpleName(), NOT_FOUND.value(), e.getMessage()));
+	}
+
+	@ExceptionHandler(BadRequestWebClientException.class)
+	protected ResponseEntity<ErrorResponse> handleBadRequestWebClientException(BadRequestWebClientException e) {
+		String timestamp = getCurrentTimestamp();
+		log.error(LOG_FORMAT, timestamp, e.getClass().getSimpleName(), e.getMessage());
+		return ResponseEntity.status(BAD_REQUEST)
+			.body(ErrorResponse.of(e.getClass().getSimpleName(), BAD_REQUEST.value(), e.getMessage()));
+	}
+
+	@ExceptionHandler(NotFoundWebClientException.class)
+	protected ResponseEntity<ErrorResponse> handleNotFoundWebClientException(NotFoundWebClientException e) {
+		String timestamp = getCurrentTimestamp();
+		log.error(LOG_FORMAT, timestamp, e.getClass().getSimpleName(), e.getMessage());
+		return ResponseEntity.status(NOT_FOUND)
+			.body(ErrorResponse.of(e.getClass().getSimpleName(), NOT_FOUND.value(), e.getMessage()));
+	}
+
+	@ExceptionHandler(InternalServerErrorWebClientException.class)
+	protected ResponseEntity<ErrorResponse> handleInternalServerErrorWebClientException(
+		InternalServerErrorWebClientException e) {
+		String timestamp = getCurrentTimestamp();
+		log.error(LOG_FORMAT, timestamp, e.getClass().getSimpleName(), e.getMessage());
+		return ResponseEntity.status(INTERNAL_SERVER_ERROR)
+			.body(ErrorResponse.of(e.getClass().getSimpleName(), INTERNAL_SERVER_ERROR.value(), e.getMessage()));
 	}
 
 	private String getCurrentTimestamp() {

--- a/src/main/java/mju/iphak/maru_egg/common/exception/custom/webClient/BadRequestWebClientException.java
+++ b/src/main/java/mju/iphak/maru_egg/common/exception/custom/webClient/BadRequestWebClientException.java
@@ -1,0 +1,13 @@
+package mju.iphak.maru_egg.common.exception.custom.webClient;
+
+import org.springframework.web.reactive.function.client.WebClientException;
+
+public class BadRequestWebClientException extends WebClientException {
+	public BadRequestWebClientException(final String msg) {
+		super(msg);
+	}
+
+	public BadRequestWebClientException(final String msg, final Throwable ex) {
+		super(msg, ex);
+	}
+}

--- a/src/main/java/mju/iphak/maru_egg/common/exception/custom/webClient/InternalServerErrorWebClientException.java
+++ b/src/main/java/mju/iphak/maru_egg/common/exception/custom/webClient/InternalServerErrorWebClientException.java
@@ -1,0 +1,13 @@
+package mju.iphak.maru_egg.common.exception.custom.webClient;
+
+import org.springframework.web.reactive.function.client.WebClientException;
+
+public class InternalServerErrorWebClientException extends WebClientException {
+	public InternalServerErrorWebClientException(final String msg) {
+		super(msg);
+	}
+
+	public InternalServerErrorWebClientException(final String msg, final Throwable ex) {
+		super(msg, ex);
+	}
+}

--- a/src/main/java/mju/iphak/maru_egg/common/exception/custom/webClient/NotFoundWebClientException.java
+++ b/src/main/java/mju/iphak/maru_egg/common/exception/custom/webClient/NotFoundWebClientException.java
@@ -1,0 +1,13 @@
+package mju.iphak.maru_egg.common.exception.custom.webClient;
+
+import org.springframework.web.reactive.function.client.WebClientException;
+
+public class NotFoundWebClientException extends WebClientException {
+	public NotFoundWebClientException(final String msg) {
+		super(msg);
+	}
+
+	public NotFoundWebClientException(final String msg, final Throwable ex) {
+		super(msg, ex);
+	}
+}

--- a/src/main/java/mju/iphak/maru_egg/question/application/QuestionProcessingService.java
+++ b/src/main/java/mju/iphak/maru_egg/question/application/QuestionProcessingService.java
@@ -60,7 +60,8 @@ public class QuestionProcessingService {
 
 	private QuestionResponse askNewQuestion(QuestionType type, QuestionCategory category, String content,
 		String contentToken) {
-		LLMAskQuestionRequest askQuestionRequest = LLMAskQuestionRequest.of(type.toString(), category.toString(),
+		LLMAskQuestionRequest askQuestionRequest = LLMAskQuestionRequest.of(type.toString(),
+			isCategoryNullThen(category),
 			content);
 
 		LLMAnswerResponse llmAnswerResponse = answerService.askQuestion(askQuestionRequest).block();
@@ -68,6 +69,13 @@ public class QuestionProcessingService {
 		Question newQuestion = saveQuestion(type, category, content, contentToken);
 		Answer newAnswer = saveAnswer(newQuestion, llmAnswerResponse.answer());
 		return createQuestionResponse(newQuestion, newAnswer);
+	}
+
+	private static String isCategoryNullThen(final QuestionCategory category) {
+		if (category.toString() == null) {
+			return QuestionCategory.UNCLASSIFIED.getQuestionCategory();
+		}
+		return category.toString();
 	}
 
 	private Answer saveAnswer(final Question question, final String content) {

--- a/src/main/java/mju/iphak/maru_egg/question/domain/QuestionCategory.java
+++ b/src/main/java/mju/iphak/maru_egg/question/domain/QuestionCategory.java
@@ -13,7 +13,7 @@ public enum QuestionCategory {
 	PAST_QUESTIONS("기출문제"),
 	UNIV_LIFE("대학생활"),
 	INTERVIEW_PRACTICAL_TEST("면접/실기"),
-	ETC("기타");
+	UNCLASSIFIED("미분류");
 
 	private final String questionCategory;
 

--- a/src/main/java/mju/iphak/maru_egg/question/dto/request/QuestionRequest.java
+++ b/src/main/java/mju/iphak/maru_egg/question/dto/request/QuestionRequest.java
@@ -19,7 +19,7 @@ public record QuestionRequest(
 	@NotNull(message = "질문 타입은 비어있을 수 없습니다.")
 	QuestionType type,
 
-	@Schema(description = "질문 카테고리(모집요강, 입시결과, 기출 문제)")
+	@Schema(description = "질문 카테고리(모집요강, 입시결과, 기출 문제)", nullable = true)
 	QuestionCategory category,
 
 	@Schema(description = "질문 내용")


### PR DESCRIPTION
## ✅ 작업 내용
- webClient exception 추가로 예외처리 진행

## 🤔 고민 했던 부분
- WebClient exception이 따로 정의된 것들이 없기 때문에 RunTimeException을 상속한 추상 클래스인 WebClientException를 상속하여 Bad Request, Not Found, Internal Server Error를 커스텀했습니다.

## 🔊 도움이 필요한 부분
- 도움이 필요한 부분이 없다면 **삭제** 해도 됩니다.
- **팀원들의 의견이 꼭 필요한 부분**을 작성해주세요.
- **팀원들은 놓치지 않고 꼭 이 항목을 보고 의견을 주세요.**