### PR TITLE
[feat] answer reference 추가

### DIFF
--- a/src/main/java/mju/iphak/maru_egg/answer/domain/Answer.java
+++ b/src/main/java/mju/iphak/maru_egg/answer/domain/Answer.java
@@ -1,11 +1,15 @@
 package mju.iphak.maru_egg.answer.domain;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
@@ -33,6 +37,10 @@ public class Answer extends BaseEntity {
 	@OneToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "question_id", nullable = false)
 	private Question question;
+
+	@OneToMany(mappedBy = "answer", cascade = CascadeType.ALL)
+	@Builder.Default
+	private List<AnswerReference> references = new ArrayList<>();
 
 	public String getDateInformation() {
 		return "생성일자: %s, 마지막 DB 갱신일자: %s".formatted(this.getCreatedAt(), this.getUpdatedAt());
@@ -63,5 +71,4 @@ public class Answer extends BaseEntity {
 		LocalDate nowDate = LocalDate.now();
 		return Integer.parseInt(String.valueOf(nowDate.getYear()));
 	}
-
 }

--- a/src/main/java/mju/iphak/maru_egg/answer/domain/AnswerReference.java
+++ b/src/main/java/mju/iphak/maru_egg/answer/domain/AnswerReference.java
@@ -1,0 +1,45 @@
+package mju.iphak.maru_egg.answer.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import mju.iphak.maru_egg.common.entity.BaseEntity;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "answer_references")
+public class AnswerReference extends BaseEntity {
+
+	private String title;
+
+	@Column(length = 1000)
+	private String link;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "answer_id")
+	private Answer answer;
+
+	public void updateAnswer(Answer answer) {
+		this.answer = answer;
+		answer.getReferences().add(this);
+	}
+
+	public static AnswerReference of(String title, String link, Answer answer) {
+		return AnswerReference.builder()
+			.title(title)
+			.link(link)
+			.answer(answer)
+			.build();
+	}
+}

--- a/src/main/java/mju/iphak/maru_egg/answer/dto/response/AnswerReferenceResponse.java
+++ b/src/main/java/mju/iphak/maru_egg/answer/dto/response/AnswerReferenceResponse.java
@@ -1,0 +1,16 @@
+package mju.iphak.maru_egg.answer.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record AnswerReferenceResponse(
+	String title,
+	String link
+) {
+	public static AnswerReferenceResponse of(String title, String link) {
+		return AnswerReferenceResponse.builder()
+			.title(title)
+			.link(link)
+			.build();
+	}
+}

--- a/src/main/java/mju/iphak/maru_egg/answer/dto/response/LLMAnswerResponse.java
+++ b/src/main/java/mju/iphak/maru_egg/answer/dto/response/LLMAnswerResponse.java
@@ -1,19 +1,32 @@
 package mju.iphak.maru_egg.answer.dto.response;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
 import lombok.Builder;
 import mju.iphak.maru_egg.answer.domain.Answer;
 
-@Builder
 public record LLMAnswerResponse(
 	String questionType,
 	String questionCategory,
-	String answer
+	String answer,
+	List<AnswerReferenceResponse> references
 ) {
-	public static LLMAnswerResponse of(String questionType, String questionCategory, Answer answer) {
+	@Builder
+	public LLMAnswerResponse {
+		if (Objects.isNull(references)) {
+			references = new ArrayList<>();
+		}
+	}
+
+	public static LLMAnswerResponse of(String questionType, String questionCategory, Answer answer,
+		List<AnswerReferenceResponse> references) {
 		return LLMAnswerResponse.builder()
 			.questionType(questionType)
 			.questionCategory(questionCategory)
 			.answer(answer.getContent())
+			.references(references)
 			.build();
 	}
 }

--- a/src/main/java/mju/iphak/maru_egg/answer/repository/AnswerReferenceRepository.java
+++ b/src/main/java/mju/iphak/maru_egg/answer/repository/AnswerReferenceRepository.java
@@ -1,0 +1,8 @@
+package mju.iphak.maru_egg.answer.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import mju.iphak.maru_egg.answer.domain.AnswerReference;
+
+public interface AnswerReferenceRepository extends JpaRepository<AnswerReference, Long> {
+}

--- a/src/main/java/mju/iphak/maru_egg/question/dto/response/QuestionResponse.java
+++ b/src/main/java/mju/iphak/maru_egg/question/dto/response/QuestionResponse.java
@@ -1,7 +1,10 @@
 package mju.iphak.maru_egg.question.dto.response;
 
+import java.util.List;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
+import mju.iphak.maru_egg.answer.dto.response.AnswerReferenceResponse;
 import mju.iphak.maru_egg.answer.dto.response.AnswerResponse;
 import mju.iphak.maru_egg.question.domain.Question;
 
@@ -16,7 +19,17 @@ import mju.iphak.maru_egg.question.domain.Question;
 	    "content": "2024년 수시 일정은 다음과 같습니다:\\n\\n- 전체 전형 2024.12.19.(목)~12.26.(목) 18:00: 최초합격자 발표 및 시충원 관련 내용 공지 예정\\n- 문서등록 및 등록금 납부 기간: 2025. 2. 10.(월) 10:00 ~ 2. 12.(수) 15:00\\n- 등록금 납부 기간: 2024.12.16.(월) 10:00 ~ 12. 18.(수) 15:00\\n\\n추가로, 복수지원 관련하여 수시모집의 모든 전형에 중복 지원이 가능하며, 최대 6개 이내의 전형에만 지원할 수 있습니다. 반드시 지정 기간 내에 문서등록과 최종 등록(등록금 납부)을 해야 합니다. 또한, 합격자는 합격한 대학에 등록하지 않을 경우 합격 포기로 간주되니 유의하시기 바랍니다.",
 	    "renewalYear": 2024,
 	    "dateInformation": "생성일자: 2024-07-15T23:36:59.847690, 마지막 DB 갱신일자: 2024-07-15T23:36:59.847690"
-	  }
+	  },
+	  "references": [
+			{
+				"title": "2025학년도 수시모집",
+				"link": "https://iphak.mju.ac.kr/main/"
+			},
+			{
+				"title": "2025학년도 정시모집",
+				"link": "https://iphak.mju.ac.kr/main/"
+			}
+	  	]
 	}
 	""")
 public record QuestionResponse(
@@ -30,15 +43,20 @@ public record QuestionResponse(
 	String dateInformation,
 
 	@Schema(description = "답변 DTO")
-	AnswerResponse answer
+	AnswerResponse answer,
+
+	@Schema(description = "답변 DTO")
+	List<AnswerReferenceResponse> references
 ) {
 
-	public static QuestionResponse of(Question question, AnswerResponse answer) {
+	public static QuestionResponse of(Question question, AnswerResponse answerResponse,
+		List<AnswerReferenceResponse> answerReferenceResponses) {
 		return QuestionResponse.builder()
 			.id(question.getId())
 			.content(question.getContent())
 			.dateInformation(question.getDateInformation())
-			.answer(answer)
+			.answer(answerResponse)
+			.references(answerReferenceResponses)
 			.build();
 	}
 }

--- a/src/test/java/mju/iphak/maru_egg/answer/application/AnswerServiceTest.java
+++ b/src/test/java/mju/iphak/maru_egg/answer/application/AnswerServiceTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.Before;
@@ -20,6 +22,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 import jakarta.persistence.EntityNotFoundException;
 import mju.iphak.maru_egg.answer.domain.Answer;
 import mju.iphak.maru_egg.answer.dto.request.LLMAskQuestionRequest;
+import mju.iphak.maru_egg.answer.dto.response.AnswerReferenceResponse;
 import mju.iphak.maru_egg.answer.dto.response.LLMAnswerResponse;
 import mju.iphak.maru_egg.answer.repository.AnswerRepository;
 import mju.iphak.maru_egg.common.MockTest;
@@ -104,10 +107,12 @@ public class AnswerServiceTest extends MockTest {
 		LLMAskQuestionRequest request = LLMAskQuestionRequest.of(QuestionType.SUSI.getType(),
 			QuestionCategory.ADMISSION_GUIDELINE.getCategory(),
 			question.getContent());
+		List<AnswerReferenceResponse> references = new ArrayList<>(
+			List.of(AnswerReferenceResponse.of("테스트 title", "테스트 link")));
 
 		// when
 		LLMAnswerResponse expectedResponse = LLMAnswerResponse.of(QuestionType.SUSI.getType(),
-			QuestionCategory.ADMISSION_GUIDELINE.getCategory(), answer);
+			QuestionCategory.ADMISSION_GUIDELINE.getCategory(), answer, references);
 		LLMAnswerResponse result = answerService.askQuestion(request).block();
 
 		// then

--- a/src/test/java/mju/iphak/maru_egg/question/api/QuestionControllerTest.java
+++ b/src/test/java/mju/iphak/maru_egg/question/api/QuestionControllerTest.java
@@ -6,6 +6,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -23,7 +24,10 @@ import org.springframework.web.reactive.function.client.WebClient;
 
 import mju.iphak.maru_egg.answer.application.AnswerService;
 import mju.iphak.maru_egg.answer.domain.Answer;
+import mju.iphak.maru_egg.answer.domain.AnswerReference;
+import mju.iphak.maru_egg.answer.dto.response.AnswerReferenceResponse;
 import mju.iphak.maru_egg.answer.dto.response.AnswerResponse;
+import mju.iphak.maru_egg.answer.repository.AnswerReferenceRepository;
 import mju.iphak.maru_egg.answer.repository.AnswerRepository;
 import mju.iphak.maru_egg.common.IntegrationTest;
 import mju.iphak.maru_egg.common.dto.pagination.SliceQuestionResponse;
@@ -55,10 +59,14 @@ class QuestionControllerTest extends IntegrationTest {
 	private AnswerRepository answerRepository;
 
 	@Autowired
+	private AnswerReferenceRepository answerReferenceRepository;
+
+	@Autowired
 	private AnswerService answerService;
 
 	private Question question;
 	private Answer answer;
+	private AnswerReference answerReference;
 	private QuestionType type;
 	private QuestionCategory category;
 	private String content;
@@ -87,6 +95,7 @@ class QuestionControllerTest extends IntegrationTest {
 			QuestionCategory.ADMISSION_GUIDELINE));
 		answer = answerRepository.save(Answer.of(question,
 			"수시 일정은 2024년 12월 19일(목)부터 2024년 12월 26일(목) 18:00까지 최초합격자 발표가 있고, 2025년 2월 10일(월) 10:00부터 2025년 2월 12일(수) 15:00까지 문서등록 및 등록금 납부가 진행됩니다. 등록금 납부 기간은 2024년 12월 16일(월) 10:00부터 2024년 12월 18일(수) 15:00까지이며, 방법은 입학처 홈페이지를 통한 문서등록 및 등록금 납부를 하시면 됩니다. 상세 안내는 추후 입학처 홈페이지를 통해 공지될 예정입니다."));
+		answerReference = answerReferenceRepository.save(AnswerReference.of("테스트 title", "테스트 link", answer));
 
 		WebClient webClient = WebClient.builder()
 			.exchangeFunction(exchangeFunction)
@@ -144,7 +153,9 @@ class QuestionControllerTest extends IntegrationTest {
 		AnswerResponse answerResponse = AnswerResponse.from(answer);
 
 		FindQuestionsRequest request = new FindQuestionsRequest(type, null);
-		QuestionResponse response = QuestionResponse.of(question, answerResponse);
+		List<AnswerReferenceResponse> references = new ArrayList<>(
+			List.of(AnswerReferenceResponse.of("테스트 title", "테스트 link")));
+		QuestionResponse response = QuestionResponse.of(question, answerResponse, references);
 
 		// when
 		ResultActions resultActions = requestFindQuestionsWithoutCategory(request);

--- a/src/test/java/mju/iphak/maru_egg/question/application/QuestionServiceTest.java
+++ b/src/test/java/mju/iphak/maru_egg/question/application/QuestionServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -30,6 +31,7 @@ import com.google.gson.Gson;
 import mju.iphak.maru_egg.answer.application.AnswerService;
 import mju.iphak.maru_egg.answer.domain.Answer;
 import mju.iphak.maru_egg.answer.dto.request.LLMAskQuestionRequest;
+import mju.iphak.maru_egg.answer.dto.response.AnswerReferenceResponse;
 import mju.iphak.maru_egg.answer.dto.response.LLMAnswerResponse;
 import mju.iphak.maru_egg.answer.repository.AnswerRepository;
 import mju.iphak.maru_egg.common.MockTest;
@@ -68,8 +70,10 @@ class QuestionServiceTest extends MockTest {
 		formData.add("question", request.question());
 		Question testQuestion = Question.of("새로운 질문입니다.", "새로운 질문", QuestionType.SUSI,
 			QuestionCategory.ADMISSION_GUIDELINE);
+		List<AnswerReferenceResponse> references = new ArrayList<>(
+			List.of(AnswerReferenceResponse.of("테스트 title", "테스트 link")));
 		LLMAnswerResponse expectedResponse = LLMAnswerResponse.of(QuestionType.SUSI.getType(),
-			QuestionCategory.ADMISSION_GUIDELINE.getCategory(), Answer.of(testQuestion, "새로운 답변입니다."));
+			QuestionCategory.ADMISSION_GUIDELINE.getCategory(), Answer.of(testQuestion, "새로운 답변입니다."), references);
 
 		mockWebServer.enqueue(new MockResponse()
 			.setHeader("Content-type", MediaType.APPLICATION_JSON_VALUE)


### PR DESCRIPTION
## ✅ 작업 내용
- LLM 서버에서 답변의 출처를 확인 후 answer에 일대다로 매핑합니다.
- 답변이 처음 생성될 때 한번에 insert 하게 됩니다.

## 🤔 고민 했던 부분
- 참고자료를 저장할 때, 한번에 저장하게 되는데 이 수가 많다면 [bulk insert](https://velog.io/@kevin_/%EC%9A%B0%EB%8B%B9%ED%83%95%ED%83%95-JDBC-Bulk-Insert-%EB%8F%84%EC%9E%85%EA%B8%B0)를 고려해볼 수 있겠지만, 3개씩 저장하기로 했으므로, 작업 오버헤드를 줄이고자 간단하게 saveAll()을 적용했습니다.