### PR TITLE
[refactor] 텍스트 추출검사 추가

### DIFF
--- a/src/test/java/mju/iphak/maru_egg/question/utils/PhraseExtractionUtilsTest.java
+++ b/src/test/java/mju/iphak/maru_egg/question/utils/PhraseExtractionUtilsTest.java
@@ -1,20 +1,64 @@
 package mju.iphak.maru_egg.question.utils;
 
+import static mju.iphak.maru_egg.question.utils.PhraseExtractionUtils.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.jupiter.api.Test;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class PhraseExtractionUtilsTest {
-
-	@Test
-	public void testExtractPhrases() {
-		// given
-		String text = "면접평가는 언제 진행되나요?";
-
-		// when
-		String result = PhraseExtractionUtils.extractPhrases(text);
+	@DisplayName("텍스트 추출 검사")
+	@ParameterizedTest(name = "{index} => input={0}")
+	@MethodSource("inputQuestions")
+	public void testExtractPhrases(String input, String contentToken) {
+		// given // when
+		String result = PhraseExtractionUtils.extractPhrases(input);
 
 		// then
-		assertEquals("면접 평가 언제 진행", result);
+		System.out.println("============================================================");
+		System.out.println("\ninput: " + input);
+		System.out.println("contentToken: " + extractPhrases(input) + "\n");
+		System.out.println("============================================================\n");
+
+		assertEquals(contentToken, result);
+	}
+
+	private static Stream<Arguments> inputQuestions() {
+		return Stream.of(
+			Arguments.of("수시 원서접수 기간 알려줘", "수시 원서 접수 기간"),
+			Arguments.of("수시 모집기간 알려줘", "수시 모집 기간"),
+			Arguments.of("수시 모집 알려줘", "수시 모집"),
+			Arguments.of("수시 원서접수 기간 알려줘", "수시 원서 접수 기간"),
+			Arguments.of("수시 원서 접수", "수시 원서 접수"),
+			Arguments.of("수시 원서", "수시 원서"),
+			Arguments.of("정시 원서 기간 알려줘", "정시 원서 기간"),
+			Arguments.of("정시 원서 접수 기간이 언제야", "정시 원서 접수 기간 언제"),
+			Arguments.of("정시 원서", "정시 원서"),
+			Arguments.of("정시 원서 기간", "정시 원서 기간"),
+			Arguments.of("입학 시험은 무엇이 필요한가요?", "입학 시험 무엇"),
+			Arguments.of("입학 시험 필요한거 내놔", "입학 시험"),
+			Arguments.of("수시 입학 요강에 대해 알려주세요.", "수시 입학 요강 대해"),
+			Arguments.of("수시 모집 요강알려줘", "수시 모집 요강"),
+			Arguments.of("모집요강에 대해 설명해줘", "모집 요강 대해 설명"),
+			Arguments.of("수시 일정 설명해줘", "수시 일정 설명"),
+			Arguments.of("크리스천리더전형 알려줘", "크리스천 리더 전형"),
+			Arguments.of("학생부 교과 전형 알려줘", "학생 부 교과 전형"),
+			Arguments.of("교과면접전형에 대해 알려줘", "교과 접전 대해"),
+			Arguments.of("학생부 종합 전형에 대해 소개해줘", "학생 부 종합 전형 대해 소개"),
+			Arguments.of("학생부 종합 서류전형과 학생부 종합 면접전형의 차이가 뭐야?", "학생 부 종합 서류 전형 학생 부 종합 면접 전형 차이 뭐"),
+			Arguments.of("수시로 지원할때 수능 최저 있어?", "지원 때 수능 최저"),
+			Arguments.of("학생부교과는 뭐야?", "학생 부교 뭐"),
+			Arguments.of("교과면접에 대해 알려줘", "교과 면접 대해"),
+			Arguments.of("학교장추천전형과 교과면접의 차이는 뭐야?", "학교장 추천 전형 교과 면접 뭐"),
+			Arguments.of("교과면접전형 일정 알려줘", "교과 면접 전형 일정"),
+			Arguments.of("교과면접 전형에 대해 알려줘", "교과 면접 전형 대해"),
+			Arguments.of("학생부교과전형에 대해 알려줘", "학생 부교 전형 대해"),
+			Arguments.of("학생부 교과전형에 대해 알려줘", "학생 부 교과 전형 대해"),
+			Arguments.of("학교장추천전형알려줘", "학교장 추천 전형")
+		);
 	}
 }


### PR DESCRIPTION
## ✅ 작업 내용
-텍스트 추출검사 test 추가

## 🤔 고민 했던 부분
- 현재 사용중인 [text 추출 API](https://github.com/open-korean-text/open-korean-text/tree/master)에서 "학생부교과전형"을 "학생 부교 전형" 으로 추출하는 문제가 발견되었습니다.
- 질문에 대한 멱등성을 유지하는 것이 목적인 기능이므로 크리티컬한 문제는 아니라 판단되지만, 주요한 기능에 의존도를 가지고 있기에 특정되는 단어들에 대해 따로 처리하는 방법을 고안해야할 것 같습니다.
