### PR TITLE
[refactor] 잘못된 질문 대답 수정

### DIFF
--- a/src/main/java/mju/iphak/maru_egg/answer/application/AnswerManager.java
+++ b/src/main/java/mju/iphak/maru_egg/answer/application/AnswerManager.java
@@ -35,7 +35,10 @@ public class AnswerManager {
 	private static final String INVALID_ANSWER_ONE = "해당 내용에 대한 정보는 존재하지 않습니다.";
 	private static final String INVALID_ANSWER_TWO = "제공된 정보 내에서 답변할 수 없습니다.";
 	private static final String BASE_MESSAGE = "질문해주신 내용에 대한 적절한 정보을 발견하지 못 했습니다.\n\n대신 질문해주신 내용에 가장 적합한 자료들을 골라봤어요. 참고하셔서 다시 질문해주세요!\n\n\n\n";
+	private static final String REFERENCE_TEXT_AND_LINK = "참고자료 %d : **[%s [바로가기]](%s)**\n\n";
 	private static final String IPHAK_OFFICE_NUMBER_GUIDE = "\n\n입학처 상담 전화번호 : 02-300-1799, 1800";
+	private static final String PAGE_SPLIT_REGEX = "page=";
+	private static final String PAGE_ANNOUNCE = "의 페이지 ";
 
 	private final QuestionRepository questionRepository;
 	private final AnswerApiClient answerApiClient;
@@ -90,15 +93,18 @@ public class AnswerManager {
 
 	private static String getGuideAnswer(final List<AnswerReferenceResponse> references) {
 		return BASE_MESSAGE + references.stream()
-			.map(reference -> String.format("참고자료 %d : [%s](%s)\n\n",
-				references.indexOf(reference) + 1,
-				reference.title(),
-				reference.link()))
+			.map(reference -> {
+				String page = PAGE_ANNOUNCE + reference.link().split(PAGE_SPLIT_REGEX)[1];
+				String title = reference.title() + page;
+				return String.format(REFERENCE_TEXT_AND_LINK,
+					references.indexOf(reference) + 1,
+					title,
+					reference.link());
+			})
 			.collect(Collectors.joining("\n")) + IPHAK_OFFICE_NUMBER_GUIDE;
 	}
 
 	private boolean isInvalidAnswer(LLMAnswerResponse llmAnswerResponse) {
-		System.out.println(llmAnswerResponse.answer());
 		return llmAnswerResponse.answer() == null || llmAnswerResponse.answer().contains(INVALID_ANSWER_ONE)
 			|| llmAnswerResponse.answer().contains(INVALID_ANSWER_TWO);
 	}

--- a/src/main/java/mju/iphak/maru_egg/answer/application/AnswerManager.java
+++ b/src/main/java/mju/iphak/maru_egg/answer/application/AnswerManager.java
@@ -35,7 +35,7 @@ public class AnswerManager {
 	private static final String INVALID_ANSWER_ONE = "해당 내용에 대한 정보는 존재하지 않습니다.";
 	private static final String INVALID_ANSWER_TWO = "제공된 정보 내에서 답변할 수 없습니다.";
 	private static final String BASE_MESSAGE = "질문해주신 내용에 대한 적절한 정보을 발견하지 못 했습니다.\n\n대신 질문해주신 내용에 가장 적합한 자료들을 골라봤어요. 참고하셔서 다시 질문해주세요!\n\n\n\n";
-	private static final String REFERENCE_TEXT_AND_LINK = "참고자료 %d : **[%s [바로가기]](%s)**\n\n";
+	private static final String REFERENCE_TEXT_AND_LINK = "**참고자료 %d : [%s [바로가기]](%s)**\n\n";
 	private static final String IPHAK_OFFICE_NUMBER_GUIDE = "\n\n입학처 상담 전화번호 : 02-300-1799, 1800";
 	private static final String PAGE_SPLIT_REGEX = "page=";
 	private static final String PAGE_ANNOUNCE = "의 페이지 ";

--- a/src/main/java/mju/iphak/maru_egg/answer/application/AnswerManager.java
+++ b/src/main/java/mju/iphak/maru_egg/answer/application/AnswerManager.java
@@ -38,7 +38,7 @@ public class AnswerManager {
 	private static final String REFERENCE_TEXT_AND_LINK = "**참고자료 %d** : [%s **[바로가기]**](%s)\n\n";
 	private static final String IPHAK_OFFICE_NUMBER_GUIDE = "\n\n입학처 상담 전화번호 : 02-300-1799, 1800";
 	private static final String PAGE_SPLIT_REGEX = "page=";
-	private static final String PAGE_ANNOUNCE = "의 페이지 ";
+	private static final String PAGE_ANNOUNCE = "페이지 ";
 
 	private final QuestionRepository questionRepository;
 	private final AnswerApiClient answerApiClient;
@@ -94,8 +94,8 @@ public class AnswerManager {
 	private static String getGuideAnswer(final List<AnswerReferenceResponse> references) {
 		return BASE_MESSAGE + references.stream()
 			.map(reference -> {
-				String page = PAGE_ANNOUNCE + reference.link().split(PAGE_SPLIT_REGEX)[1];
-				String title = reference.title() + page;
+				String page = reference.link().split(PAGE_SPLIT_REGEX)[1] + PAGE_ANNOUNCE;
+				String title = reference.title() + " " + page;
 				return String.format(REFERENCE_TEXT_AND_LINK,
 					references.indexOf(reference) + 1,
 					title,

--- a/src/main/java/mju/iphak/maru_egg/answer/application/AnswerManager.java
+++ b/src/main/java/mju/iphak/maru_egg/answer/application/AnswerManager.java
@@ -35,7 +35,7 @@ public class AnswerManager {
 	private static final String INVALID_ANSWER_ONE = "해당 내용에 대한 정보는 존재하지 않습니다.";
 	private static final String INVALID_ANSWER_TWO = "제공된 정보 내에서 답변할 수 없습니다.";
 	private static final String BASE_MESSAGE = "질문해주신 내용에 대한 적절한 정보을 발견하지 못 했습니다.\n\n대신 질문해주신 내용에 가장 적합한 자료들을 골라봤어요. 참고하셔서 다시 질문해주세요!\n\n\n\n";
-	private static final String REFERENCE_TEXT_AND_LINK = "**참고자료 %d : [%s [바로가기]](%s)**\n\n";
+	private static final String REFERENCE_TEXT_AND_LINK = "**참고자료 %d** : [%s **[바로가기]**](%s)\n\n";
 	private static final String IPHAK_OFFICE_NUMBER_GUIDE = "\n\n입학처 상담 전화번호 : 02-300-1799, 1800";
 	private static final String PAGE_SPLIT_REGEX = "page=";
 	private static final String PAGE_ANNOUNCE = "의 페이지 ";


### PR DESCRIPTION
## ✅ 작업 내용
- 잘못된 질문에 대한 대답 폼 변경
- llm에서 들어온 link의 페이지를 추출하여 사용자에게 제공하도록 로직 수정

![image](https://github.com/user-attachments/assets/011f919b-e232-4ed5-9ad6-1da113f7c96d)

## 🤔 고민한 부분
- 해당 작업은 답변에 대한 형식 즉, view에 대한 작업을 담고 있습니다. mvc 패턴의 관점을 보았을 때 controller에서 view의 역할을 수행하고 있다고 볼 수 있는 것입니다.
- 그러나 일전에 결정한 아키텍쳐에서 Client - Web Server - WAS - LLM(외부 AI 서버) 의 구조를 결정했으므로 서버는 LLM에서 오는 답변을 가공하여 Client로 넘기는 책임을 가지게 됩니다.
- 따라서, 질문에 대한 valid를 판단하여 올바른 값을 전달하는 역할로 따졌을 때 이 작업은 서버단에서 해결하는 것이 맞다고 판단했습니다.
- 또한 이 작업이 한 페이지를 작업하는 것도 아닌 대답에 한정되어있기 때문에 충분히 가능한 작업이라고 판단했습니다. 