### PR TITLE
[refactor] 연관 관계 수정

### DIFF
--- a/src/main/java/mju/iphak/maru_egg/question/domain/Question.java
+++ b/src/main/java/mju/iphak/maru_egg/question/domain/Question.java
@@ -6,12 +6,14 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import mju.iphak.maru_egg.answer.domain.Answer;
 import mju.iphak.maru_egg.common.entity.BaseEntity;
 
 @Getter
@@ -38,6 +40,9 @@ public class Question extends BaseEntity {
 
 	@ColumnDefault("false")
 	private boolean isChecked;
+
+	@OneToOne(mappedBy = "question", orphanRemoval = true)
+	private Answer answer;
 
 	public String getDateInformation() {
 		return "생성일자: %s, 마지막 DB 갱신일자: %s".formatted(this.getCreatedAt(), this.getUpdatedAt());

--- a/src/test/java/mju/iphak/maru_egg/answer/repository/AnswerRepositoryTest.java
+++ b/src/test/java/mju/iphak/maru_egg/answer/repository/AnswerRepositoryTest.java
@@ -29,8 +29,8 @@ class AnswerRepositoryTest extends RepositoryTest {
 
 	@BeforeEach
 	public void setUp() throws Exception {
-		Question question = new Question("테스트 질문입니다.", "테스트 질문", QuestionType.JEONGSI,
-			QuestionCategory.ADMISSION_GUIDELINE, 0, false);
+		Question question = Question.of("테스트 질문입니다.", "테스트 질문", QuestionType.JEONGSI,
+			QuestionCategory.ADMISSION_GUIDELINE);
 		questionRepository.save(question);
 		Answer answer = Answer.of(question, "테스트 답변입니다.");
 		answerRepository.save(answer);

--- a/src/test/java/mju/iphak/maru_egg/question/repository/QuestionRepositoryTest.java
+++ b/src/test/java/mju/iphak/maru_egg/question/repository/QuestionRepositoryTest.java
@@ -29,8 +29,8 @@ class QuestionRepositoryTest extends RepositoryTest {
 
 	@BeforeEach
 	public void setUp() throws Exception {
-		question = new Question("테스트 질문 예시 예시입니다.", "테스트 질문 예시", QuestionType.SUSI,
-			QuestionCategory.ADMISSION_GUIDELINE, 0, false);
+		question = Question.of("테스트 질문 예시 예시입니다.", "테스트 질문 예시", QuestionType.SUSI,
+			QuestionCategory.ADMISSION_GUIDELINE);
 		questionRepository.save(question);
 		Question additionalQuestion1 = Question.of("추가1 테스트 질문 예시입니다.", "추가 테스트 질문 예시", QuestionType.SUSI,
 			QuestionCategory.ADMISSION_GUIDELINE);


### PR DESCRIPTION
## ✅ 작업 내용
- 연관 관계 수정
- `orphanRemoval = true` 로 부모 제거시 자식까지 제거하도록 수정
https://tecoble.techcourse.co.kr/post/2021-08-15-jpa-cascadetype-remove-vs-orphanremoval-true/