### PR TITLE
[feat] 질문타입 상태 관리 API 추가

### DIFF
--- a/src/main/java/mju/iphak/maru_egg/answer/api/AdminAnswerController.java
+++ b/src/main/java/mju/iphak/maru_egg/answer/api/AdminAnswerController.java
@@ -1,6 +1,6 @@
 package mju.iphak.maru_egg.answer.api;
 
-import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -25,7 +25,7 @@ public class AdminAnswerController implements AdminAnswerControllerDocs {
 		@CustomApiResponse(error = "EntityNotFoundException", status = 404, message = "답변 id가 123131인 답변을 찾을 수 없습니다.", description = "답변을 찾지 못한 경우"),
 		@CustomApiResponse(error = "InternalServerError", status = 500, message = "내부 서버 오류가 발생했습니다.", description = "내부 서버 오류")
 	})
-	@PostMapping()
+	@PutMapping()
 	public void updateAnswerContent(@Valid @RequestBody UpdateAnswerContentRequest request) {
 		answerManager.updateAnswerContent(request.id(), request.content());
 	}

--- a/src/main/java/mju/iphak/maru_egg/common/exception/ErrorCode.java
+++ b/src/main/java/mju/iphak/maru_egg/common/exception/ErrorCode.java
@@ -26,6 +26,7 @@ public enum ErrorCode {
 	NOT_FOUND_ANSWER_BY_QUESTION_ID(NOT_FOUND, "질문 id가 %s인 답변을 찾을 수 없습니다."),
 	NOT_FOUND_USER(NOT_FOUND, "유저 이메일이 %s인 유저를 찾을 수 없습니다."),
 	NOT_FOUND_WEBCLIENT(NOT_FOUND, "%s에서 값을 불러오지 못 했습니다."),
+	NOT_FOUND_QUESTION_TYPE_STATUS(NOT_FOUND, "질문 타입이 %s인 질문 상태를 찾을 수 없습니다."),
 
 	// 500 error
 	INTERNAL_ERROR_SIMILARITY(INTERNAL_SERVER_ERROR, "contentToken: %s, question: %s인 질문의 유사도를 검사하는 도중 오류가 발생했습니다."),

--- a/src/main/java/mju/iphak/maru_egg/question/api/AdminQuestionController.java
+++ b/src/main/java/mju/iphak/maru_egg/question/api/AdminQuestionController.java
@@ -3,6 +3,7 @@ package mju.iphak.maru_egg.question.api;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -28,9 +29,9 @@ public class AdminQuestionController implements AdminQuestionControllerDocs {
 		@CustomApiResponse(error = "EntityNotFoundException", status = 404, message = "id: 132인 질문을 찾을 수 없습니다.", description = "질문을 찾지 못한 경우"),
 		@CustomApiResponse(error = "InternalServerError", status = 500, message = "내부 서버 오류가 발생했습니다.", description = "내부 서버 오류")
 	})
-	@PostMapping("/check")
+	@PutMapping("/check")
 	public void checkQuestion(@Valid @RequestBody CheckQuestionRequest request) {
-		questionService.checkQuestion(request.questionId(), request.check());
+		questionService.checkQuestion(request.questionId());
 	}
 
 	@CustomApiResponses({

--- a/src/main/java/mju/iphak/maru_egg/question/api/AdminQuestionTypeStatusController.java
+++ b/src/main/java/mju/iphak/maru_egg/question/api/AdminQuestionTypeStatusController.java
@@ -1,0 +1,53 @@
+package mju.iphak.maru_egg.question.api;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import mju.iphak.maru_egg.common.meta.CustomApiResponse;
+import mju.iphak.maru_egg.common.meta.CustomApiResponses;
+import mju.iphak.maru_egg.question.application.QuestionTypeStatusService;
+import mju.iphak.maru_egg.question.docs.AdminQuestionTypeStatusControllerDocs;
+import mju.iphak.maru_egg.question.dto.request.UpdateQuestionTypeStatusRequest;
+import mju.iphak.maru_egg.question.dto.response.QuestionTypeStatusResponse;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/admin/questions/status")
+public class AdminQuestionTypeStatusController implements AdminQuestionTypeStatusControllerDocs {
+
+	private final QuestionTypeStatusService questionTypeStatusService;
+
+	@CustomApiResponses({
+		@CustomApiResponse(error = "InternalServerError", status = 500, message = "내부 서버 오류가 발생했습니다.", description = "내부 서버 오류")
+	})
+	@PostMapping("/init")
+	public void initializeQuestionTypeStatus() {
+		questionTypeStatusService.initializeQuestionTypeStatus();
+	}
+
+	@CustomApiResponses({
+		@CustomApiResponse(error = "HttpMessageNotReadableException", status = 400, message = "\"Invalid input format: JSON parse error: Cannot deserialize value of type `java.lang.Long` from String \\\"잘못된 형식의 질문 ID\\\": not a valid `java.lang.Long` value\"", description = "json 형식 및 타입에 맞지 않은 요청을 할 경우"),
+		@CustomApiResponse(error = "EntityNotFoundException", status = 404, message = "질문 타입이 수시인 질문 상태를 찾을 수 없습니다", description = "해당 타입을 찾을 수 없는 경우"),
+		@CustomApiResponse(error = "InternalServerError", status = 500, message = "내부 서버 오류가 발생했습니다.", description = "내부 서버 오류")
+	})
+	@PutMapping()
+	public void updateQuestionTypeStatus(@Valid @RequestBody UpdateQuestionTypeStatusRequest request) {
+		questionTypeStatusService.updateStatus(request.type());
+	}
+
+	@CustomApiResponses({
+		@CustomApiResponse(error = "InternalServerError", status = 500, message = "내부 서버 오류가 발생했습니다.", description = "내부 서버 오류")
+	})
+	@GetMapping()
+	public List<QuestionTypeStatusResponse> getQuestionTypeStatus() {
+		return questionTypeStatusService.getQuestionTypeStatus();
+	}
+}

--- a/src/main/java/mju/iphak/maru_egg/question/application/QuestionService.java
+++ b/src/main/java/mju/iphak/maru_egg/question/application/QuestionService.java
@@ -62,11 +62,11 @@ public class QuestionService {
 		return response;
 	}
 
-	public void checkQuestion(final Long id, final boolean check) {
+	public void checkQuestion(final Long id) {
 		Question question = questionRepository.findById(id)
 			.orElseThrow(() -> new EntityNotFoundException(
 				String.format(NOT_FOUND_QUESTION_BY_ID.getMessage(), id)));
-		question.updateIsChecked(check);
+		question.updateIsChecked();
 	}
 
 	public void createQuestion(final CreateQuestionRequest request) {

--- a/src/main/java/mju/iphak/maru_egg/question/application/QuestionTypeStatusService.java
+++ b/src/main/java/mju/iphak/maru_egg/question/application/QuestionTypeStatusService.java
@@ -1,0 +1,56 @@
+package mju.iphak.maru_egg.question.application;
+
+import static mju.iphak.maru_egg.common.exception.ErrorCode.*;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import mju.iphak.maru_egg.question.domain.QuestionType;
+import mju.iphak.maru_egg.question.domain.QuestionTypeStatus;
+import mju.iphak.maru_egg.question.dto.response.QuestionTypeStatusResponse;
+import mju.iphak.maru_egg.question.repository.QuestionTypeStatusRepository;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+@Transactional
+public class QuestionTypeStatusService {
+
+	private final QuestionTypeStatusRepository questionTypeStatusRepository;
+
+	public void initializeQuestionTypeStatus() {
+		List<QuestionTypeStatus> questionTypeStatuses = QuestionTypeStatus.initialize();
+		if (!isDatabaseEmpty()) {
+			questionTypeStatusRepository.deleteAll();
+		}
+		questionTypeStatusRepository.saveAll(questionTypeStatuses);
+	}
+
+	public void updateStatus(final QuestionType type) {
+		QuestionTypeStatus questionTypeStatus = questionTypeStatusRepository.findByQuestionType(type)
+			.orElseThrow(() -> new EntityNotFoundException(
+				String.format(NOT_FOUND_QUESTION_TYPE_STATUS.getMessage(), type)));
+		questionTypeStatus.updateStatus();
+	}
+
+	public List<QuestionTypeStatusResponse> getQuestionTypeStatus() {
+		List<QuestionTypeStatus> questionTypeStatuses = questionTypeStatusRepository.findAll();
+		return questionTypeStatuses.stream()
+			.map(questionTypeStatus -> QuestionTypeStatusResponse.of(questionTypeStatus.getQuestionType(),
+				questionTypeStatus.isActivated()))
+			.toList();
+	}
+
+	public void deleteQuestionTypeStatus(QuestionType type) {
+		questionTypeStatusRepository.deleteByQuestionType(type);
+	}
+
+	private boolean isDatabaseEmpty() {
+		return questionTypeStatusRepository.count() == 0;
+	}
+}

--- a/src/main/java/mju/iphak/maru_egg/question/docs/AdminQuestionTypeStatusControllerDocs.java
+++ b/src/main/java/mju/iphak/maru_egg/question/docs/AdminQuestionTypeStatusControllerDocs.java
@@ -1,0 +1,31 @@
+package mju.iphak.maru_egg.question.docs;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.RequestBody;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import mju.iphak.maru_egg.question.dto.request.UpdateQuestionTypeStatusRequest;
+import mju.iphak.maru_egg.question.dto.response.QuestionTypeStatusResponse;
+
+@Tag(name = "Admin QuestionTypeStatus API", description = "어드민 질문타입 상태 관련 API 입니다.")
+public interface AdminQuestionTypeStatusControllerDocs {
+
+	@Operation(summary = "질문타입 초기화", description = "현재 제공 중인 질문 타입에 대해 DB에 초기화합니다.", responses = {
+		@ApiResponse(responseCode = "200", description = "질문타입 초기화 성공")
+	})
+	void initializeQuestionTypeStatus();
+
+	@Operation(summary = "질문타입 상태 변경", description = "질문타입의 상태를 변경합니다. (true <-> false)", responses = {
+		@ApiResponse(responseCode = "200", description = "질문타입 상태 변경 성공")
+	})
+	void updateQuestionTypeStatus(@Valid @RequestBody UpdateQuestionTypeStatusRequest request);
+
+	@Operation(summary = "전체 질문타입과 상태 조회", description = "전체 질문타입과 상태를 조회합니다.", responses = {
+		@ApiResponse(responseCode = "200", description = "전체 질문타입과 상태 조회 성공")
+	})
+	List<QuestionTypeStatusResponse> getQuestionTypeStatus();
+}

--- a/src/main/java/mju/iphak/maru_egg/question/domain/Question.java
+++ b/src/main/java/mju/iphak/maru_egg/question/domain/Question.java
@@ -52,8 +52,8 @@ public class Question extends BaseEntity {
 		this.viewCount++;
 	}
 
-	public void updateIsChecked(boolean isChecked) {
-		this.isChecked = isChecked;
+	public void updateIsChecked() {
+		this.isChecked = !this.isChecked;
 	}
 
 	public static Question of(String content, String contentToken, QuestionType questionType,

--- a/src/main/java/mju/iphak/maru_egg/question/domain/QuestionTypeStatus.java
+++ b/src/main/java/mju/iphak/maru_egg/question/domain/QuestionTypeStatus.java
@@ -1,0 +1,50 @@
+package mju.iphak.maru_egg.question.domain;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.hibernate.annotations.ColumnDefault;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import mju.iphak.maru_egg.common.entity.BaseEntity;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "question_type_status")
+public class QuestionTypeStatus extends BaseEntity {
+
+	@Enumerated(EnumType.STRING)
+	private QuestionType questionType;
+
+	@ColumnDefault("true")
+	private boolean isActivated;
+
+	public void updateStatus() {
+		this.isActivated = !this.isActivated;
+	}
+
+	public static List<QuestionTypeStatus> initialize() {
+		QuestionType[] types = QuestionType.values();
+		return Arrays.stream(types)
+			.map(QuestionTypeStatus::of)
+			.toList();
+	}
+
+	public static QuestionTypeStatus of(QuestionType type) {
+		return QuestionTypeStatus.builder()
+			.questionType(type)
+			.isActivated(true)
+			.build();
+	}
+}

--- a/src/main/java/mju/iphak/maru_egg/question/dto/request/CheckQuestionRequest.java
+++ b/src/main/java/mju/iphak/maru_egg/question/dto/request/CheckQuestionRequest.java
@@ -7,9 +7,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record CheckQuestionRequest(
 
 	@Parameter(description = "질문 id", example = "1")
-	Long questionId,
-
-	@Parameter(description = "질문-답변 확인 상태", example = "true")
-	boolean check
+	Long questionId
 ) {
 }

--- a/src/main/java/mju/iphak/maru_egg/question/dto/request/UpdateQuestionTypeStatusRequest.java
+++ b/src/main/java/mju/iphak/maru_egg/question/dto/request/UpdateQuestionTypeStatusRequest.java
@@ -1,0 +1,12 @@
+package mju.iphak.maru_egg.question.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import mju.iphak.maru_egg.question.domain.QuestionType;
+
+@Schema(description = "질문 목록 요청 DTO")
+public record UpdateQuestionTypeStatusRequest(
+
+	@Schema(description = "질문 타입(수시, 정시, 편입학)", allowableValues = {"SUSI", "JEONGSI", "PYEONIP"})
+	QuestionType type
+) {
+}

--- a/src/main/java/mju/iphak/maru_egg/question/dto/response/QuestionTypeStatusResponse.java
+++ b/src/main/java/mju/iphak/maru_egg/question/dto/response/QuestionTypeStatusResponse.java
@@ -1,0 +1,21 @@
+package mju.iphak.maru_egg.question.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import mju.iphak.maru_egg.question.domain.QuestionType;
+
+@Builder
+public record QuestionTypeStatusResponse(
+	@Schema(description = "질문 타입(수시, 정시, 편입학)", allowableValues = {"SUSI", "JEONGSI", "PYEONIP"})
+	QuestionType type,
+
+	@Schema(description = "활성화된 질문타입 (true면 활성화, false면 비활성화)", example = "true")
+	boolean isActivated
+) {
+	public static QuestionTypeStatusResponse of(QuestionType type, boolean isActivated) {
+		return QuestionTypeStatusResponse.builder()
+			.type(type)
+			.isActivated(isActivated)
+			.build();
+	}
+}

--- a/src/main/java/mju/iphak/maru_egg/question/repository/QuestionTypeStatusRepository.java
+++ b/src/main/java/mju/iphak/maru_egg/question/repository/QuestionTypeStatusRepository.java
@@ -1,0 +1,14 @@
+package mju.iphak.maru_egg.question.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import mju.iphak.maru_egg.question.domain.QuestionType;
+import mju.iphak.maru_egg.question.domain.QuestionTypeStatus;
+
+public interface QuestionTypeStatusRepository extends JpaRepository<QuestionTypeStatus, Long> {
+	Optional<QuestionTypeStatus> findByQuestionType(QuestionType type);
+
+	void deleteByQuestionType(final QuestionType questionType);
+}

--- a/src/test/java/mju/iphak/maru_egg/answer/api/AdminAnswerControllerTest.java
+++ b/src/test/java/mju/iphak/maru_egg/answer/api/AdminAnswerControllerTest.java
@@ -71,7 +71,7 @@ class AdminAnswerControllerTest extends IntegrationTest {
 	}
 
 	private void performRequestAndExpectStatus(Object content, ResultMatcher expectedStatus) throws Exception {
-		ResultActions resultActions = mvc.perform(post("/api/admin/answers")
+		ResultActions resultActions = mvc.perform(put("/api/admin/answers")
 			.contentType(MediaType.APPLICATION_JSON)
 			.content(objectMapper.writeValueAsString(content)));
 
@@ -79,7 +79,7 @@ class AdminAnswerControllerTest extends IntegrationTest {
 	}
 
 	private void performRequestAndExpectStatus(String content, ResultMatcher expectedStatus) throws Exception {
-		ResultActions resultActions = mvc.perform(post("/api/admin/answers")
+		ResultActions resultActions = mvc.perform(put("/api/admin/answers")
 			.contentType(MediaType.APPLICATION_JSON)
 			.content(content));
 

--- a/src/test/java/mju/iphak/maru_egg/question/api/AdminQuestionControllerTest.java
+++ b/src/test/java/mju/iphak/maru_egg/question/api/AdminQuestionControllerTest.java
@@ -37,7 +37,7 @@ class AdminQuestionControllerTest extends IntegrationTest {
 	@Test
 	void 질문_체크_API_정상적인_요청() throws Exception {
 		// given
-		CheckQuestionRequest request = new CheckQuestionRequest(1L, true);
+		CheckQuestionRequest request = new CheckQuestionRequest(1L);
 
 		// when
 		ResultActions resultActions = performCheckQuestionRequest(request);
@@ -61,9 +61,9 @@ class AdminQuestionControllerTest extends IntegrationTest {
 	@Test
 	void 질문_체크_API_존재하지_않는_질문_ID() throws Exception {
 		// given
-		CheckQuestionRequest request = new CheckQuestionRequest(999L, true);
+		CheckQuestionRequest request = new CheckQuestionRequest(999L);
 		doThrow(new EntityNotFoundException("질문을 찾을 수 없습니다.")).when(questionService)
-			.checkQuestion(anyLong(), anyBoolean());
+			.checkQuestion(anyLong());
 
 		// when
 		ResultActions resultActions = performCheckQuestionRequest(request);
@@ -75,9 +75,9 @@ class AdminQuestionControllerTest extends IntegrationTest {
 	@Test
 	void 질문_체크_API_서버_내부_오류() throws Exception {
 		// given
-		CheckQuestionRequest request = new CheckQuestionRequest(1L, true);
+		CheckQuestionRequest request = new CheckQuestionRequest(1L);
 		doThrow(new RuntimeException("내부 서버 오류")).when(questionService)
-			.checkQuestion(anyLong(), anyBoolean());
+			.checkQuestion(anyLong());
 
 		// when
 		ResultActions resultActions = performCheckQuestionRequest(request);
@@ -111,14 +111,14 @@ class AdminQuestionControllerTest extends IntegrationTest {
 	}
 
 	private ResultActions performCheckQuestionRequest(CheckQuestionRequest request) throws Exception {
-		return mvc.perform(post("/api/admin/questions/check")
+		return mvc.perform(put("/api/admin/questions/check")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
 			.andDo(print());
 	}
 
 	private ResultActions performCheckQuestionRequest(String invalidJson) throws Exception {
-		return mvc.perform(post("/api/admin/questions/check")
+		return mvc.perform(put("/api/admin/questions/check")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(invalidJson))
 			.andDo(print());

--- a/src/test/java/mju/iphak/maru_egg/question/api/AdminQuestionTypeStatusControllerTest.java
+++ b/src/test/java/mju/iphak/maru_egg/question/api/AdminQuestionTypeStatusControllerTest.java
@@ -1,0 +1,84 @@
+package mju.iphak.maru_egg.question.api;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.ResultActions;
+
+import mju.iphak.maru_egg.common.IntegrationTest;
+import mju.iphak.maru_egg.question.application.QuestionTypeStatusService;
+import mju.iphak.maru_egg.question.domain.QuestionType;
+import mju.iphak.maru_egg.question.dto.request.UpdateQuestionTypeStatusRequest;
+
+@WithMockUser(roles = "ADMIN")
+class AdminQuestionTypeStatusControllerTest extends IntegrationTest {
+
+	@Autowired
+	private QuestionTypeStatusService questionTypeStatusService;
+
+	@BeforeEach
+	void setUp() {
+		MockitoAnnotations.openMocks(this);
+		questionTypeStatusService.initializeQuestionTypeStatus();
+		questionTypeStatusService.deleteQuestionTypeStatus(QuestionType.JEONGSI);
+	}
+
+	@DisplayName("200 질문 상태 초기화")
+	@Test
+	public void 질문_상태_초기화_API_정상적인_요청() throws Exception {
+		// given // when
+		ResultActions resultActions = performInitializeQuestionTypeStatus();
+
+		// then
+		resultActions.andExpect(status().isOk());
+
+	}
+
+	@DisplayName("200 질문타입 상태 변경")
+	@Test
+	public void 질문타입_상태_변경_API_정상적인_요청() throws Exception {
+		// given
+		UpdateQuestionTypeStatusRequest request = new UpdateQuestionTypeStatusRequest(QuestionType.SUSI);
+
+		// when
+		ResultActions resultActions = performUpdateQuestionTypeStatus(request);
+
+		// then
+		resultActions.andExpect(status().isOk());
+	}
+
+	@DisplayName("404 질문타입 상태 변경")
+	@Test
+	public void 질문타입_상태_변경_API_존재하지_않는_질문_타입() throws Exception {
+		// given
+		UpdateQuestionTypeStatusRequest request = new UpdateQuestionTypeStatusRequest(QuestionType.JEONGSI);
+
+		// when
+		ResultActions resultActions = performUpdateQuestionTypeStatus(request);
+
+		// then
+		resultActions.andExpect(status().isNotFound());
+	}
+
+	private ResultActions performInitializeQuestionTypeStatus() throws Exception {
+		return mvc.perform(post("/api/admin/questions/status/init")
+				.contentType(MediaType.APPLICATION_JSON))
+			.andDo(print());
+	}
+
+	private ResultActions performUpdateQuestionTypeStatus(UpdateQuestionTypeStatusRequest request) throws Exception {
+		return mvc.perform(put("/api/admin/questions/status")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andDo(print());
+	}
+
+}

--- a/src/test/java/mju/iphak/maru_egg/question/application/QuestionTypeStatusServiceTest.java
+++ b/src/test/java/mju/iphak/maru_egg/question/application/QuestionTypeStatusServiceTest.java
@@ -1,0 +1,107 @@
+package mju.iphak.maru_egg.question.application;
+
+import static mju.iphak.maru_egg.common.exception.ErrorCode.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import jakarta.persistence.EntityNotFoundException;
+import mju.iphak.maru_egg.common.MockTest;
+import mju.iphak.maru_egg.question.domain.QuestionType;
+import mju.iphak.maru_egg.question.domain.QuestionTypeStatus;
+import mju.iphak.maru_egg.question.dto.response.QuestionTypeStatusResponse;
+import mju.iphak.maru_egg.question.repository.QuestionTypeStatusRepository;
+
+class QuestionTypeStatusServiceTest extends MockTest {
+
+	@MockBean
+	private QuestionTypeStatusRepository questionTypeStatusRepository;
+
+	@Autowired
+	private QuestionTypeStatusService questionTypeStatusService;
+
+	@DisplayName("질문 타입 상태 초기화 성공")
+	@Test
+	void initializeQuestionTypeStatus_Success() {
+		// given
+		when(questionTypeStatusRepository.count()).thenReturn(1L);
+
+		// when
+		questionTypeStatusService.initializeQuestionTypeStatus();
+
+		// then
+		verify(questionTypeStatusRepository, times(1)).deleteAll();
+		verify(questionTypeStatusRepository, times(1)).saveAll(any());
+	}
+
+	@DisplayName("질문 타입 상태 업데이트 성공")
+	@Test
+	void updateStatus_Success() {
+		// given
+		QuestionType type = QuestionType.SUSI;
+		QuestionTypeStatus status = new QuestionTypeStatus(type, true);
+		when(questionTypeStatusRepository.findByQuestionType(type)).thenReturn(Optional.of(status));
+
+		// when
+		questionTypeStatusService.updateStatus(type);
+
+		// then
+		verify(questionTypeStatusRepository, times(1)).findByQuestionType(type);
+		assertThat(status.isActivated()).isFalse();
+	}
+
+	@DisplayName("질문 타입 상태 업데이트 실패 - 타입 상태 없음")
+	@Test
+	void updateStatus_Failure_EntityNotFound() {
+		// given
+		QuestionType type = QuestionType.SUSI;
+		when(questionTypeStatusRepository.findByQuestionType(type)).thenReturn(Optional.empty());
+
+		// when & then
+		EntityNotFoundException exception = assertThrows(EntityNotFoundException.class,
+			() -> questionTypeStatusService.updateStatus(type));
+		assertThat(exception.getMessage()).isEqualTo(String.format(NOT_FOUND_QUESTION_TYPE_STATUS.getMessage(), type));
+	}
+
+	@DisplayName("질문 타입 상태 목록 조회 성공")
+	@Test
+	void getQuestionTypeStatus_Success() {
+		// given
+		QuestionTypeStatus status1 = new QuestionTypeStatus(QuestionType.SUSI, true);
+		QuestionTypeStatus status2 = new QuestionTypeStatus(QuestionType.JEONGSI, false);
+		when(questionTypeStatusRepository.findAll()).thenReturn(List.of(status1, status2));
+
+		// when
+		List<QuestionTypeStatusResponse> result = questionTypeStatusService.getQuestionTypeStatus();
+
+		// then
+		verify(questionTypeStatusRepository, times(1)).findAll();
+		assertThat(result).hasSize(2);
+		assertThat(result.get(0).type()).isEqualTo(QuestionType.SUSI);
+		assertThat(result.get(0).isActivated()).isTrue();
+		assertThat(result.get(1).type()).isEqualTo(QuestionType.JEONGSI);
+		assertThat(result.get(1).isActivated()).isFalse();
+	}
+
+	@DisplayName("질문 타입 상태 삭제 성공")
+	@Test
+	void deleteQuestionTypeStatus_Success() {
+		// given
+		QuestionType type = QuestionType.SUSI;
+
+		// when
+		questionTypeStatusService.deleteQuestionTypeStatus(type);
+
+		// then
+		verify(questionTypeStatusRepository, times(1)).deleteByQuestionType(eq(type));
+	}
+}

--- a/src/test/java/mju/iphak/maru_egg/question/domain/QuestionTest.java
+++ b/src/test/java/mju/iphak/maru_egg/question/domain/QuestionTest.java
@@ -18,11 +18,8 @@ class QuestionTest {
 	@DisplayName("질문이 확인 되었을 때 상태 변화 성공한 경우")
 	@Test
 	public void 질문_체크_변경_성공() {
-		// given
-		boolean check = true;
-
-		// when
-		question.updateIsChecked(check);
+		// given // when
+		question.updateIsChecked();
 
 		// then
 		assertThat(question.isChecked()).isTrue();
@@ -31,14 +28,11 @@ class QuestionTest {
 	@DisplayName("질문이 확인 되었을 때 상태 변화 실패한 경우")
 	@Test
 	public void 질문_체크_변경_실패() {
-		// given
-		boolean check = false;
-
-		// when
-		question.updateIsChecked(check);
+		// given // when
+		question.updateIsChecked();
 
 		// then
-		assertThat(question.isChecked()).isNotEqualTo(true);
+		assertThat(question.isChecked()).isNotEqualTo(false);
 	}
 
 }


### PR DESCRIPTION
## ✅ 작업 내용
- 질문타입 상태를 수정, 초기화, 전체 조회 API를 추가했습니다.
- 관련 Test를 추가했습니다.



## 📌 작업 중 Test에 대한 유효성 및 구조 개선에 대한 필요성을 느낌
- 다음 작업에서 진행