### PR TITLE
[TSK-45] refactor: 유사도 효율 증가를 위한 구조 개선

### DIFF
--- a/src/main/java/mju/iphak/maru_egg/question/application/QuestionProcessingService.java
+++ b/src/main/java/mju/iphak/maru_egg/question/application/QuestionProcessingService.java
@@ -18,10 +18,11 @@ import mju.iphak.maru_egg.answer.dto.response.AnswerReferenceResponse;
 import mju.iphak.maru_egg.answer.dto.response.AnswerResponse;
 import mju.iphak.maru_egg.common.utils.NLP.TextSimilarityUtils;
 import mju.iphak.maru_egg.common.utils.PhraseExtractionUtils;
+import mju.iphak.maru_egg.question.dao.request.SelectQuestionCores;
+import mju.iphak.maru_egg.question.dao.response.QuestionCore;
 import mju.iphak.maru_egg.question.domain.Question;
 import mju.iphak.maru_egg.question.domain.QuestionCategory;
 import mju.iphak.maru_egg.question.domain.QuestionType;
-import mju.iphak.maru_egg.question.dto.response.QuestionCore;
 import mju.iphak.maru_egg.question.dto.response.QuestionResponse;
 import mju.iphak.maru_egg.question.repository.QuestionRepository;
 
@@ -39,7 +40,8 @@ public class QuestionProcessingService {
 	public QuestionResponse question(final QuestionType type, final QuestionCategory category, final String content) {
 		String contentToken = PhraseExtractionUtils.extractPhrases(content);
 
-		List<QuestionCore> questionCores = getQuestionCores(type, category, contentToken);
+		SelectQuestionCores selectQuestionCores = SelectQuestionCores.of(type, category, content, contentToken);
+		List<QuestionCore> questionCores = getQuestionCores(selectQuestionCores);
 		if (questionCores.isEmpty()) {
 			log.info("저장된 질문이 없어 새롭게 LLM서버에 질문을 요청합니다.");
 			return answerManager.processNewQuestion(type, category, content, contentToken);

--- a/src/main/java/mju/iphak/maru_egg/question/application/QuestionProcessingService.java
+++ b/src/main/java/mju/iphak/maru_egg/question/application/QuestionProcessingService.java
@@ -59,12 +59,9 @@ public class QuestionProcessingService {
 		return getExistingQuestionResponse(questionId);
 	}
 
-	private List<QuestionCore> getQuestionCores(QuestionType type, QuestionCategory category, String contentToken) {
-		return category == null ?
-			questionRepository.searchQuestionsByContentTokenAndType(contentToken, type)
-				.orElse(Collections.emptyList()) :
-			questionRepository.searchQuestionsByContentTokenAndTypeAndCategory(contentToken, type, category)
-				.orElse(Collections.emptyList());
+	private List<QuestionCore> getQuestionCores(SelectQuestionCores selectQuestionCores) {
+		return questionRepository.searchQuestions(selectQuestionCores)
+			.orElse(Collections.emptyList());
 	}
 
 	private QuestionResponse getExistingQuestionResponse(Long questionId) {

--- a/src/main/java/mju/iphak/maru_egg/question/application/QuestionService.java
+++ b/src/main/java/mju/iphak/maru_egg/question/application/QuestionService.java
@@ -17,6 +17,7 @@ import mju.iphak.maru_egg.answer.application.AnswerManager;
 import mju.iphak.maru_egg.answer.domain.Answer;
 import mju.iphak.maru_egg.answer.dto.response.AnswerResponse;
 import mju.iphak.maru_egg.common.dto.pagination.SliceQuestionResponse;
+import mju.iphak.maru_egg.question.dao.request.SelectQuestions;
 import mju.iphak.maru_egg.question.domain.Question;
 import mju.iphak.maru_egg.question.domain.QuestionCategory;
 import mju.iphak.maru_egg.question.domain.QuestionType;
@@ -47,18 +48,10 @@ public class QuestionService {
 		final Integer size) {
 		Pageable pageable = PageRequest.of(0, size);
 		SliceQuestionResponse<SearchedQuestionsResponse> response;
-		response = questionRepository.searchQuestionsOfCursorPagingByContentWithLikeFunction(
-			type,
-			category,
-			content,
-			cursorViewCount, questionId, pageable);
-		if (response.data().isEmpty()) {
-			response = questionRepository.searchQuestionsOfCursorPagingByContentWithFullTextSearch(
-				type,
-				category,
-				content,
-				cursorViewCount, questionId, pageable);
-		}
+
+		SelectQuestions selectQuestions = SelectQuestions.of(type, category, content, cursorViewCount, questionId,
+			pageable);
+		response = questionRepository.searchQuestionsOfCursorPaging(selectQuestions);
 		return response;
 	}
 

--- a/src/main/java/mju/iphak/maru_egg/question/dao/request/SelectQuestionCores.java
+++ b/src/main/java/mju/iphak/maru_egg/question/dao/request/SelectQuestionCores.java
@@ -1,0 +1,24 @@
+package mju.iphak.maru_egg.question.dao.request;
+
+import lombok.Builder;
+import mju.iphak.maru_egg.question.domain.QuestionCategory;
+import mju.iphak.maru_egg.question.domain.QuestionType;
+
+@Builder
+public record SelectQuestionCores(
+	QuestionType type,
+	QuestionCategory category,
+	String content,
+	String contentToken
+) {
+
+	public static SelectQuestionCores of(final QuestionType type, final QuestionCategory category, final String content,
+		final String contentToken) {
+		return SelectQuestionCores.builder()
+			.type(type)
+			.category(category)
+			.content(content)
+			.contentToken(contentToken)
+			.build();
+	}
+}

--- a/src/main/java/mju/iphak/maru_egg/question/dao/request/SelectQuestions.java
+++ b/src/main/java/mju/iphak/maru_egg/question/dao/request/SelectQuestions.java
@@ -1,0 +1,33 @@
+package mju.iphak.maru_egg.question.dao.request;
+
+import org.springframework.data.domain.Pageable;
+
+import lombok.Builder;
+import mju.iphak.maru_egg.question.domain.QuestionCategory;
+import mju.iphak.maru_egg.question.domain.QuestionType;
+
+@Builder
+public record SelectQuestions(
+	QuestionType type,
+	QuestionCategory category,
+	String content,
+	Integer cursorViewCount,
+	Long questionId,
+	Pageable pageable
+) {
+	public static SelectQuestions of(QuestionType type,
+		QuestionCategory category,
+		String content,
+		Integer cursorViewCount,
+		Long questionId,
+		Pageable pageable) {
+		return SelectQuestions.builder()
+			.type(type)
+			.category(category)
+			.content(content)
+			.cursorViewCount(cursorViewCount)
+			.questionId(questionId)
+			.pageable(pageable)
+			.build();
+	}
+}

--- a/src/main/java/mju/iphak/maru_egg/question/dao/response/QuestionCore.java
+++ b/src/main/java/mju/iphak/maru_egg/question/dao/response/QuestionCore.java
@@ -1,4 +1,4 @@
-package mju.iphak.maru_egg.question.dto.response;
+package mju.iphak.maru_egg.question.dao.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;

--- a/src/main/java/mju/iphak/maru_egg/question/repository/QuestionRepositoryCustom.java
+++ b/src/main/java/mju/iphak/maru_egg/question/repository/QuestionRepositoryCustom.java
@@ -3,27 +3,15 @@ package mju.iphak.maru_egg.question.repository;
 import java.util.List;
 import java.util.Optional;
 
-import org.springframework.data.domain.Pageable;
-
 import mju.iphak.maru_egg.common.dto.pagination.SliceQuestionResponse;
-import mju.iphak.maru_egg.question.domain.QuestionCategory;
-import mju.iphak.maru_egg.question.domain.QuestionType;
-import mju.iphak.maru_egg.question.dto.response.QuestionCore;
+import mju.iphak.maru_egg.question.dao.request.SelectQuestionCores;
+import mju.iphak.maru_egg.question.dao.request.SelectQuestions;
+import mju.iphak.maru_egg.question.dao.response.QuestionCore;
 import mju.iphak.maru_egg.question.dto.response.SearchedQuestionsResponse;
 
 public interface QuestionRepositoryCustom {
-	Optional<List<QuestionCore>> searchQuestionsByContentTokenAndType(final String contentToken,
-		final QuestionType type);
+	Optional<List<QuestionCore>> searchQuestions(final SelectQuestionCores selectQuestionCores);
 
-	Optional<List<QuestionCore>> searchQuestionsByContentTokenAndTypeAndCategory(final String contentToken,
-		final QuestionType type,
-		final QuestionCategory category);
-
-	SliceQuestionResponse<SearchedQuestionsResponse> searchQuestionsOfCursorPagingByContentWithFullTextSearch(
-		final QuestionType type, final QuestionCategory category, final String content,
-		final Integer cursorViewCount, final Long questionId, final Pageable pageable);
-
-	SliceQuestionResponse<SearchedQuestionsResponse> searchQuestionsOfCursorPagingByContentWithLikeFunction(
-		final QuestionType type, final QuestionCategory category, final String content,
-		final Integer cursorViewCount, final Long questionId, final Pageable pageable);
+	SliceQuestionResponse<SearchedQuestionsResponse> searchQuestionsOfCursorPaging(
+		final SelectQuestions selectQuestions);
 }

--- a/src/test/java/mju/iphak/maru_egg/question/repository/QuestionRepositoryImplTest.java
+++ b/src/test/java/mju/iphak/maru_egg/question/repository/QuestionRepositoryImplTest.java
@@ -23,11 +23,13 @@ import mju.iphak.maru_egg.answer.domain.Answer;
 import mju.iphak.maru_egg.answer.repository.AnswerRepository;
 import mju.iphak.maru_egg.common.RepositoryTest;
 import mju.iphak.maru_egg.common.dto.pagination.SliceQuestionResponse;
+import mju.iphak.maru_egg.question.dao.request.SelectQuestionCores;
+import mju.iphak.maru_egg.question.dao.request.SelectQuestions;
+import mju.iphak.maru_egg.question.dao.response.QuestionCore;
 import mju.iphak.maru_egg.question.domain.QQuestion;
 import mju.iphak.maru_egg.question.domain.Question;
 import mju.iphak.maru_egg.question.domain.QuestionCategory;
 import mju.iphak.maru_egg.question.domain.QuestionType;
-import mju.iphak.maru_egg.question.dto.response.QuestionCore;
 import mju.iphak.maru_egg.question.dto.response.SearchedQuestionsResponse;
 
 class QuestionRepositoryImplTest extends RepositoryTest {
@@ -109,7 +111,7 @@ class QuestionRepositoryImplTest extends RepositoryTest {
 		QQuestion question = QQuestion.question;
 		String contentToken = "수시 입학 요강 대해";
 		QuestionType type = QuestionType.SUSI;
-		NumberTemplate<Double> numberTemplate = createBooleanTemplate(question, contentToken);
+		NumberTemplate<Double> numberTemplate = createBooleanTemplateByContentToken(question, contentToken);
 
 		// when
 		List<Question> results = queryFactory.selectFrom(question)
@@ -126,11 +128,11 @@ class QuestionRepositoryImplTest extends RepositoryTest {
 	void contentToken_type으로_질문_검색_실패() {
 		// given
 		String invalidContentToken = "잘못된 질문";
-		QuestionType type = QuestionType.SUSI;
+		SelectQuestionCores selectQuestionCores = SelectQuestionCores.of(QuestionType.SUSI, null, invalidContentToken,
+			invalidContentToken);
 
 		// when
-		Optional<List<QuestionCore>> result = questionRepositoryImpl.searchQuestionsByContentTokenAndType(
-			invalidContentToken, type);
+		Optional<List<QuestionCore>> result = questionRepositoryImpl.searchQuestions(selectQuestionCores);
 
 		// then
 		assertThat(result).isPresent();
@@ -145,7 +147,7 @@ class QuestionRepositoryImplTest extends RepositoryTest {
 		String contentToken = "수시 입학 요강 대해";
 		QuestionType type = QuestionType.SUSI;
 		QuestionCategory category = QuestionCategory.ADMISSION_GUIDELINE;
-		NumberTemplate<Double> numberTemplate = createBooleanTemplate(question, contentToken);
+		NumberTemplate<Double> numberTemplate = createBooleanTemplateByContentToken(question, contentToken);
 
 		// when
 		List<String> results = queryFactory.select(question.contentToken)
@@ -165,12 +167,12 @@ class QuestionRepositoryImplTest extends RepositoryTest {
 	void contentToken_type_Category로_질문_검색_실패() {
 		// given
 		String invalidContentToken = "잘못된 질문";
-		QuestionType type = QuestionType.SUSI;
-		QuestionCategory category = QuestionCategory.ADMISSION_GUIDELINE;
+		SelectQuestionCores selectQuestionCores = SelectQuestionCores.of(QuestionType.SUSI,
+			QuestionCategory.ADMISSION_GUIDELINE, invalidContentToken,
+			invalidContentToken);
 
 		// when
-		Optional<List<QuestionCore>> result = questionRepositoryImpl.searchQuestionsByContentTokenAndTypeAndCategory(
-			invalidContentToken, type, category);
+		Optional<List<QuestionCore>> result = questionRepositoryImpl.searchQuestions(selectQuestionCores);
 
 		// then
 		assertThat(result).isPresent();
@@ -182,13 +184,13 @@ class QuestionRepositoryImplTest extends RepositoryTest {
 	void content로_질문_페이지네이션_조회_실패() {
 		// given
 		String content = "존재하지 않는 질문";
-		QuestionType type = QuestionType.SUSI;
-		QuestionCategory category = QuestionCategory.ADMISSION_GUIDELINE;
 		Pageable pageable = PageRequest.of(0, 3);
+		SelectQuestions selectQuestions = SelectQuestions.of(QuestionType.SUSI, QuestionCategory.ADMISSION_GUIDELINE,
+			content, null, null, pageable);
 
 		// when
-		SliceQuestionResponse<SearchedQuestionsResponse> result = questionRepositoryImpl.searchQuestionsOfCursorPagingByContentWithFullTextSearch(
-			type, category, content, null, null, pageable);
+		SliceQuestionResponse<SearchedQuestionsResponse> result = questionRepositoryImpl.searchQuestionsOfCursorPaging(
+			selectQuestions);
 
 		// then
 		assertThat(result.data()).isEmpty();
@@ -199,7 +201,7 @@ class QuestionRepositoryImplTest extends RepositoryTest {
 		QQuestion question = QQuestion.question;
 		String contentToken = "수시 입학 요강 대해";
 		QuestionType type = QuestionType.SUSI;
-		NumberTemplate<Double> numberTemplate = createBooleanTemplate(question, contentToken);
+		NumberTemplate<Double> numberTemplate = createBooleanTemplateByContentToken(question, contentToken);
 
 		List<String> results = queryFactory.select(question.contentToken)
 			.from(question)
@@ -216,7 +218,7 @@ class QuestionRepositoryImplTest extends RepositoryTest {
 		QQuestion question = QQuestion.question;
 		String contentToken = "수시 입학 요강 대해";
 
-		NumberTemplate<Double> numberTemplate = createBooleanTemplate(question, contentToken);
+		NumberTemplate<Double> numberTemplate = createBooleanTemplateByContentToken(question, contentToken);
 
 		// when
 		List<Question> results = queryFactory.selectFrom(question)
@@ -233,7 +235,7 @@ class QuestionRepositoryImplTest extends RepositoryTest {
 		// given
 		QQuestion question = QQuestion.question;
 		String invalidContentToken = "존재하지 않는 질문";
-		NumberTemplate<Double> numberTemplate = createBooleanTemplate(question, invalidContentToken);
+		NumberTemplate<Double> numberTemplate = createBooleanTemplateByContentToken(question, invalidContentToken);
 
 		// when
 		List<Question> results = queryFactory.selectFrom(question)
@@ -244,7 +246,7 @@ class QuestionRepositoryImplTest extends RepositoryTest {
 		assertThat(results).isEmpty();
 	}
 
-	private NumberTemplate<Double> createBooleanTemplate(QQuestion question, String content) {
+	private NumberTemplate<Double> createBooleanTemplateByContentToken(QQuestion question, String content) {
 		return Expressions.numberTemplate(Double.class, "function('match', {0}, {1})", question.content, content);
 	}
 }


### PR DESCRIPTION
## ✅ 작업 내용
- DAO 객체 생성으로 인한 Repository 메서드 추상화
- contentToken을 기반으로만 찾던 방식에서 content를 먼저 찾고 비어있는 경우에 contentToken을 기반으로 질문을 찾아낼 수 있도록 변경
- 이로 인해 더 넓은 범위의 질문을 찾아낼 수 있음
- dao를 사용해 어플리케이션에서의 역할을 줄이고, Repository와의 의존도를 줄임