### PR TITLE
hotfix: 잘못된 정보에 대한 답변 제외 필터 추가

### DIFF
--- a/src/main/java/mju/iphak/maru_egg/answer/application/AnswerManager.java
+++ b/src/main/java/mju/iphak/maru_egg/answer/application/AnswerManager.java
@@ -11,6 +11,8 @@ import org.springframework.transaction.annotation.Transactional;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import mju.iphak.maru_egg.admission.domain.AdmissionCategory;
+import mju.iphak.maru_egg.admission.domain.AdmissionType;
 import mju.iphak.maru_egg.answer.domain.Answer;
 import mju.iphak.maru_egg.answer.domain.AnswerReference;
 import mju.iphak.maru_egg.answer.dto.request.CreateAnswerRequest;
@@ -20,8 +22,6 @@ import mju.iphak.maru_egg.answer.dto.response.AnswerResponse;
 import mju.iphak.maru_egg.answer.dto.response.LLMAnswerResponse;
 import mju.iphak.maru_egg.answer.repository.AnswerReferenceRepository;
 import mju.iphak.maru_egg.answer.repository.AnswerRepository;
-import mju.iphak.maru_egg.admission.domain.AdmissionCategory;
-import mju.iphak.maru_egg.admission.domain.AdmissionType;
 import mju.iphak.maru_egg.question.domain.Question;
 import mju.iphak.maru_egg.question.dto.response.QuestionResponse;
 import mju.iphak.maru_egg.question.repository.QuestionRepository;
@@ -33,7 +33,8 @@ import mju.iphak.maru_egg.question.repository.QuestionRepository;
 public class AnswerManager {
 
 	private static final String INVALID_ANSWER_ONE = "해당 내용에 대한 정보는 존재하지 않습니다.";
-	private static final String INVALID_ANSWER_TWO = "제공된 정보 내에서 답변할 수 없습니다.";
+	private static final String INVALID_ANSWER_TWO = "제공된 정보 내에서";
+	private static final String INVALID_ANSWER_THREE = "구체적인 정보를 찾을 수 없습니다.";
 	private static final String BASE_MESSAGE = "질문해주신 내용에 대한 적절한 정보을 발견하지 못 했습니다.\n\n대신 질문해주신 내용에 가장 적합한 자료들을 골라봤어요. 참고하셔서 다시 질문해주세요!\n\n\n\n";
 	private static final String REFERENCE_TEXT_AND_LINK = "**참고자료 %d** : [%s **[바로가기]**](%s)\n\n";
 	private static final String IPHAK_OFFICE_NUMBER_GUIDE = "\n\n입학처 상담 전화번호 : 02-300-1799, 1800";
@@ -106,7 +107,8 @@ public class AnswerManager {
 
 	private boolean isInvalidAnswer(LLMAnswerResponse llmAnswerResponse) {
 		return llmAnswerResponse.answer() == null || llmAnswerResponse.answer().contains(INVALID_ANSWER_ONE)
-			|| llmAnswerResponse.answer().contains(INVALID_ANSWER_TWO);
+			|| llmAnswerResponse.answer().contains(INVALID_ANSWER_TWO)
+			|| llmAnswerResponse.answer().contains(INVALID_ANSWER_THREE);
 	}
 
 	private Question saveQuestion(AdmissionType type, AdmissionCategory category, String content, String contentToken) {

--- a/src/test/java/mju/iphak/maru_egg/answer/application/AnswerManagerTest.java
+++ b/src/test/java/mju/iphak/maru_egg/answer/application/AnswerManagerTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.Test;
@@ -14,19 +15,27 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import jakarta.persistence.EntityNotFoundException;
-import mju.iphak.maru_egg.answer.domain.Answer;
-import mju.iphak.maru_egg.answer.dto.request.CreateAnswerRequest;
-import mju.iphak.maru_egg.answer.repository.AnswerRepository;
-import mju.iphak.maru_egg.common.MockTest;
 import mju.iphak.maru_egg.admission.domain.AdmissionCategory;
 import mju.iphak.maru_egg.admission.domain.AdmissionType;
+import mju.iphak.maru_egg.answer.domain.Answer;
+import mju.iphak.maru_egg.answer.dto.request.CreateAnswerRequest;
+import mju.iphak.maru_egg.answer.dto.request.LLMAskQuestionRequest;
+import mju.iphak.maru_egg.answer.dto.response.AnswerReferenceResponse;
+import mju.iphak.maru_egg.answer.dto.response.LLMAnswerResponse;
+import mju.iphak.maru_egg.answer.repository.AnswerRepository;
+import mju.iphak.maru_egg.common.MockTest;
 import mju.iphak.maru_egg.question.domain.Question;
 import mju.iphak.maru_egg.question.dto.request.CreateQuestionRequest;
+import mju.iphak.maru_egg.question.dto.response.QuestionResponse;
+import reactor.core.publisher.Mono;
 
 public class AnswerManagerTest extends MockTest {
 
 	@Mock
 	private AnswerRepository answerRepository;
+
+	@Mock
+	private AnswerApiClient answerApiClient;
 
 	@InjectMocks
 	private AnswerManager answerManager;
@@ -88,4 +97,35 @@ public class AnswerManagerTest extends MockTest {
 
 		assertThat("답변 id가 1인 답변을 찾을 수 없습니다.").isEqualTo(exception.getMessage());
 	}
+
+	@DisplayName("Invalid 답변 필터링 테스트")
+	@Test
+	public void invalid_답변_저장_안됨() {
+		// given
+		AdmissionType admissionType = AdmissionType.SUSI;
+		AdmissionCategory admissionCategory = AdmissionCategory.ADMISSION_GUIDELINE;
+		String content = "명지대학교 크리스천리더 화공신소재환경공학부의 입시 결과";
+		String contentToken = "명지대학교 크리스천리더 화공신소재환경공학부 입시 결과";
+
+		LLMAnswerResponse invalidResponse = LLMAnswerResponse.of(
+			AdmissionType.SUSI.getType(),
+			AdmissionCategory.ADMISSION_GUIDELINE.getCategory(),
+			Answer.of(
+				question,
+				"제공된 정보 내에서 명지대학교 크리스천리더 화공신소재환경공학부의 입시 결과에 대한 구체적인 정보를 찾을 수 없습니다. 더욱 자세한 상담을 원하시면 명지대학교 입학처 02-300-1799,1800으로 전화주시길 바랍니다."
+			),
+			List.of(AnswerReferenceResponse.of("테스트 title", "http://example.com/page=1"))
+		);
+
+		when(answerApiClient.askQuestion(any(LLMAskQuestionRequest.class))).thenReturn(Mono.just(invalidResponse));
+
+		// when
+		QuestionResponse response = answerManager.processNewQuestion(admissionType, admissionCategory, content,
+			contentToken);
+
+		// then
+		assertThat(response).isNotNull();
+		verify(answerRepository, times(0)).save(any(Answer.class));
+	}
+
 }


### PR DESCRIPTION
## ✅ 작업 내용
- `AnswerManager` 클래스에서 `getGuideAnswer` 메서드의 예외 처리 로직을 수정하여 `PAGE_SPLIT_REGEX`가 포함되지 않은 링크에서도 안전하게 처리하도록 변경했습니다.
- `AnswerManagerTest` 클래스의 `invalid_답변_저장_안됨` 테스트 케이스를 추가하여, Invalid한 답변이 저장되지 않고 필터링되는지 확인할 수 있도록 테스트를 작성했습니다.

## 🤔 고민했던 부분
- **예외 처리 방식**: `getGuideAnswer` 메서드에서 `PAGE_SPLIT_REGEX`가 포함되지 않은 링크를 처리할 때 `ArrayIndexOutOfBoundsException` 예외가 발생하지 않도록, 링크를 나눈 배열의 길이를 체크하는 조건을 추가했습니다. 예외 발생 가능성을 줄이기 위해 다른 예외 처리 방식도 검토했지만, 배열 길이 체크가 가장 명확한 해결책으로 판단되었습니다.
- **테스트 케이스의 일관성 유지**: `invalid_답변_저장_안됨` 테스트에서 `link`에 `"http://example.com/page=1"`을 설정하여 `PAGE_SPLIT_REGEX` 조건이 만족되도록 하고, Invalid 답변이 저장되지 않는지 검증하였습니다.

## 🔊 도움이 필요한 부분
- `AnswerManager`의 Invalid 답변 필터링 로직에서 `INVALID_ANSWER_ONE`, `INVALID_ANSWER_TWO`, `INVALID_ANSWER_THREE` 문자열 외에 추가적인 조건이 필요한지에 대해 팀원들의 의견이 필요합니다.