### PR TITLE
[TSK-62] infra: 모니터링 서버 분리

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -3,6 +3,7 @@ name: MARU EGG CI-CD Workflow
 on:
   push:
     branches: [ "main", "develop" ]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -139,12 +140,12 @@ jobs:
             echo "GITHUB_RUN_NUMBER=${GITHUB_RUN_NUMBER}"
             envsubst < <(echo "${{ secrets.DOCKER_COMPOSE_DEV }}") > docker-compose.yml
             echo ${{ secrets.DOCKER_PASSWORD }} | sudo docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
-            SERVICES_TO_STOP=$(sudo docker ps --format '{{.Names}}' | grep -Ev '(nginx|grafana)')
+            SERVICES_TO_STOP=$(sudo docker ps --format '{{.Names}}' | grep -Ev '(nginx)')
             if [ ! -z "$SERVICES_TO_STOP" ]; then
               echo "Stopping services: $SERVICES_TO_STOP"
               sudo docker stop $SERVICES_TO_STOP
             fi
-            SERVICES_TO_REMOVE=$(sudo docker ps -a --format '{{.Names}}' | grep -Ev '(nginx|grafana)')
+            SERVICES_TO_REMOVE=$(sudo docker ps -a --format '{{.Names}}' | grep -Ev '(nginx)')
             if [ ! -z "$SERVICES_TO_REMOVE" ]; then
               echo "Removing services: $SERVICES_TO_REMOVE"
               sudo docker rm $SERVICES_TO_REMOVE
@@ -153,8 +154,42 @@ jobs:
             sudo docker-compose -f docker-compose.yml up -d
             sudo docker image prune -f
 
-      - name: Remove GitHub Actions IP
-        run: |
-          aws ec2 revoke-security-group-ingress \
-              --group-id ${{ secrets.EC2_SECURITY_GROUP_ID }} \
-              --protocol tcp --port 22 --cidr "${{ env.ip }}/32"
+  deploy-monitor:
+    runs-on: ubuntu-latest
+
+    if: github.event_name == 'workflow_dispatch'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: 'ap-northeast-2'
+
+      - name: Copy docker-compose-monitor.yml into monitor instance
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{ secrets.MONITOR_PUBLIC_DNS }}
+          username: ${{ secrets.USERNAME }}
+          key: ${{ secrets.PEM_KEY }}
+          source: "docker/docker-compose-monitor.yml"
+          target: "/home/${{ secrets.MONITOR_USERNAME }}/docker/docker-compose-monitor.yml"
+          strip_components: 3
+          overwrite: true
+          debug: true
+
+      - name: Deploy to EC2 monitor server
+        uses: appleboy/ssh-action@v0.1.0
+        with:
+          host: ${{ secrets.MONITOR_PUBLIC_DNS }}
+          username: ${{ secrets.MONITOR_USERNAME }}
+          key: ${{ secrets.MONITOR_PEM_KEY }}
+          script: |
+            cd /home/${{ secrets.MONITOR_USERNAME }}
+            echo ${{ secrets.DOCKER_PASSWORD }} | sudo docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+            sudo docker-compose -f docker-compose-monitor.yml up -d
+            sudo docker image prune -f

--- a/docker/docker-compose-monitor.yml
+++ b/docker/docker-compose-monitor.yml
@@ -1,0 +1,33 @@
+services:
+  prometheus:
+    image: prom/prometheus
+    container_name: prometheus
+    volumes:
+      - ./prometheus/config/prometheus.yml:/etc/prometheus/prometheus.yml
+      - ./prometheus/prometheus-volume:/prometheus
+    ports:
+      - '9090:9090'
+    command:
+      - '--web.enable-lifecycle'
+      - '--config.file=/etc/prometheus/prometheus.yml'
+    restart: on-failure
+    networks:
+      - monitor-net
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana_container
+    ports:
+      - 3000:3000
+    volumes:
+      - ./grafana/config/grafana.ini:/etc/grafana/grafana.ini
+      - ./grafana/volume:/var/lib/grafana
+    environment:
+      - GRAFANA_ADMIN_USER=${GRAFANA_USER}
+      - GRAFANA_ADMIN_PASSWORD=${GRAFANA_PASSWORD}
+    restart: always
+    networks:
+      - monitor-net
+
+networks:
+  monitor-net:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,24 +9,6 @@ services:
     volumes:
       - /home/ec2-user/logs:/logs
 
-  prometheus:
-    image: prom/prometheus
-    container_name: prometheus
-    volumes:
-      - ./prometheus/config/prometheus.yml:/etc/prometheus/prometheus.yml
-      - ./prometheus/prometheus-volume:/prometheus
-    ports:
-      - '9090:9090'
-    command:
-      - '--web.enable-lifecycle'
-      - '--config.file=/etc/prometheus/prometheus.yml'
-    restart: on-failure
-    depends_on:
-      - maru-egg-app
-    networks:
-      - maru-egg-dev
-    user: '65534:65534'
-
   nginx:
     depends_on:
       - maru-egg-app
@@ -41,19 +23,5 @@ services:
     networks:
       - maru-egg-dev
 
-  grafana:
-    image: grafana/grafana:latest
-    container_name: grafana_container
-    ports:
-      - 3000:3000
-    volumes:
-      - ./grafana/config/grafana.ini:/etc/grafana/grafana.ini
-      - ./grafana/volume:/var/lib/grafana
-    environment:
-      - GRAFANA_ADMIN_USER=${GRAFANA_USER}
-      - GRAFANA_ADMIN_PASSWORD=${GRAFANA_PASSWORD}
-    restart: always
-    networks:
-      - maru-egg-dev
 networks:
   maru-egg-dev:

--- a/docker/prometheus/config/prometheus.yml
+++ b/docker/prometheus/config/prometheus.yml
@@ -18,4 +18,5 @@ scrape_configs:
     scheme: 'https'
     static_configs:
       - targets:
-          - 'marueggserver.com'
+          - 'marueggserver.com:8080'
+          - { MONITOR_SERVER_IP }:8080


### PR DESCRIPTION
### ✅ 작업 내용  
- **모니터링 CI/CD 파이프라인 추가**  
  - Prometheus 및 Grafana를 자동 배포할 수 있도록 CI/CD 파이프라인을 구축했습니다.  
  - Prometheus의 설정 파일인 `prometheus.yml`이 GitHub Actions를 통해 배포 시 동기화되도록 구성했습니다.  

- **모니터링 Docker Compose 분리**  
  - 기존 애플리케이션 서버(t2.micro)에서 Spring 애플리케이션, Grafana, Prometheus가 모두 한 서버에서 구동되어 부하가 발생하는 문제가 있었습니다.  
  - 모니터링 시스템을 별도의 서버로 분리하고, 각 서비스에 맞는 Docker Compose 파일을 따로 작성했습니다.  

- **Prometheus `prometheus.yml` Pull 방식으로 설정**  
  - `prometheus.yml` 파일을 Pull 방식으로 설정하여 모니터링 대상이 `/metrics` 엔드포인트를 통해 메트릭 데이터를 제공하도록 구성했습니다.  
  - 서비스 디스커버리를 활용하여 새로운 서비스가 추가되거나 변경될 때 자동으로 모니터링 대상에 포함되도록 설정했습니다.  

---

### 🧐 고민한 점  

1. **기존 서버(t2.micro)의 문제점**  
   - 기존 서버는 Spring 애플리케이션, Grafana, Prometheus가 함께 실행되며, 서버 리소스(t2.micro)가 부족한 상황이었습니다.  
   - 특히, Prometheus와 Grafana는 메트릭 데이터를 처리하고 시각화하는 과정에서 높은 CPU와 메모리를 요구합니다.  
   - 따라서, 애플리케이션 성능 저하 및 모니터링 중단 가능성이 존재했습니다.  

2. **서버 분리**  
   - 모니터링 서버를 별도로 구성하여 애플리케이션 서버와 분리함으로써 성능 문제를 해결했습니다.  
   - 분리된 서버는 Prometheus와 Grafana만 구동되며, 메트릭 데이터 수집 및 시각화에 집중합니다.  

3. **Push vs Pull 방식의 선택**  
   - Prometheus에서 메트릭 데이터를 수집하는 방식으로 Push와 Pull 두 가지 옵션이 있었습니다.  
     
     #### Push 방식  
     - 대상 시스템이 Prometheus 서버로 데이터를 주기적으로 전송합니다.  
     - 실시간 데이터 처리에 적합하나, 보안 및 서버 부하 관리가 어렵습니다.  
     
     #### Pull 방식  
     - Prometheus가 대상 시스템의 `/metrics` 엔드포인트에 직접 접근하여 데이터를 가져옵니다.  
     - 네트워크 구성이 간단하고, 서비스 디스커버리를 활용해 동적으로 새로운 서비스 모니터링이 가능합니다.  

   - 위의 장단점을 검토한 결과, **Pull 방식을 선택**했습니다.  
     - 네트워크 보안 및 자동화된 서비스 디스커버리가 주요 요인이었습니다.  
     - Prometheus가 대상 시스템의 `/metrics` 데이터를 주기적으로 수집하도록 설정했습니다.  

4. **결론**  
   - 모니터링 서버를 별도로 분리함으로써 성능 문제를 해결하고, Prometheus의 Pull 방식을 활용해 네트워크 보안성과 확장성을 확보했습니다.  
   - CI/CD 파이프라인을 추가해 모니터링 관련 서비스 배포를 자동화하며, 지속적인 모니터링 시스템 운영이 가능해졌습니다.  

### 🚀 기대 효과  
- 애플리케이션 서버의 부하를 줄이고, 안정적인 운영 환경을 마련.  
- 별도의 모니터링 서버를 통해 시스템 장애 시에도 대응 가능.  
- 서비스 디스커버리 및 Pull 방식을 활용한 유연한 확장성 확보.  
- CI/CD를 통한 배포 자동화로 운영 효율성 극대화.  