### PR TITLE
[TSK-65] infra: log 수집 방법 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -146,6 +146,7 @@ dependencies {
     // 모니터링
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
+    implementation 'org.codehaus.janino:janino:3.1.9'
 }
 
 tasks.named('test') {

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -36,6 +36,8 @@ services:
       - ./logs/all:/var/logs/all
       - ./logs/warn:/var/logs/warn
       - ./logs/error:/var/logs/error
+      - ./logs/invalid_qna:/var/logs/invalid_qna
+      - ./logs/new_qna:/var/logs/new_qna
     command:
       - -config.file=/etc/promtail/promtail-config.yml
     networks:

--- a/docker/promtail/config/promtail-config.yml
+++ b/docker/promtail/config/promtail-config.yml
@@ -17,6 +17,22 @@ scrape_configs:
           job: all_logs
           __path__: /var/logs/all/*.log
 
+  - job_name: new_qna
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: new_qna_logs
+          __path__: /var/logs/new_qna/*.log
+
+  - job_name: invalid_qna
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: invalid_qna_logs
+          __path__: /var/logs/invalid_qna/*.log
+
   - job_name: warn
     static_configs:
       - targets:

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,6 +1,51 @@
 <configuration>
     <!-- 전체 설정의 시작 -->
 
+    <!-- 새로운 질문 Appender -->
+    <appender name="NEW_QNA_LOG" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>logs/specific/logFile.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>logs/new_qna/logFile.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <maxHistory>30</maxHistory>
+            <totalSizeCap>100MB</totalSizeCap>
+        </rollingPolicy>
+        <encoder>
+            <pattern>%-4relative [%thread] %-5level %logger{35} - %msg%n</pattern>
+        </encoder>
+
+        <!-- 메시지 필터 설정 -->
+        <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
+            <evaluator class="ch.qos.logback.classic.boolex.JaninoEventEvaluator">
+                <expression>message.contains("[NEW")</expression>
+            </evaluator>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+    </appender>
+
+    <!-- 답변 못한 질문 Appender -->
+    <appender name="INVALID_QNA_LOG" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>logs/specific/logFile.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>logs/invalid_qna/logFile.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <maxHistory>30</maxHistory>
+            <totalSizeCap>100MB</totalSizeCap>
+        </rollingPolicy>
+        <encoder>
+            <pattern>%-4relative [%thread] %-5level %logger{35} - %msg%n</pattern>
+        </encoder>
+
+        <!-- 메시지 필터 설정 -->
+        <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
+            <evaluator class="ch.qos.logback.classic.boolex.JaninoEventEvaluator">
+                <expression>message.contains("[INVALID")</expression>
+            </evaluator>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+    </appender>
+
+
     <!-- INFO 이상 모든 로그를 기록할 Appender -->
     <appender name="ALL_LOG" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>logs/all/logFile.log</file>
@@ -51,5 +96,7 @@
         <appender-ref ref="ALL_LOG"/>
         <appender-ref ref="WARN_LOG"/>
         <appender-ref ref="ERROR_LOG"/>
+        <appender-ref ref="NEW_QNA_LOG"/>
+        <appender-ref ref="INVALID_QNA_LOG"/>
     </root>
 </configuration>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,9 +1,8 @@
 <configuration>
     <!-- 전체 설정의 시작 -->
 
-    <!-- 새로운 질문 Appender -->
     <appender name="NEW_QNA_LOG" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>logs/specific/logFile.log</file>
+        <file>logs/new_qna/logFile.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <fileNamePattern>logs/new_qna/logFile.%d{yyyy-MM-dd}.log</fileNamePattern>
             <maxHistory>30</maxHistory>
@@ -12,8 +11,6 @@
         <encoder>
             <pattern>%-4relative [%thread] %-5level %logger{35} - %msg%n</pattern>
         </encoder>
-
-        <!-- 메시지 필터 설정 -->
         <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
             <evaluator class="ch.qos.logback.classic.boolex.JaninoEventEvaluator">
                 <expression>message.contains("[NEW")</expression>
@@ -23,9 +20,8 @@
         </filter>
     </appender>
 
-    <!-- 답변 못한 질문 Appender -->
     <appender name="INVALID_QNA_LOG" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>logs/specific/logFile.log</file>
+        <file>logs/invalid_qna/logFile.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <fileNamePattern>logs/invalid_qna/logFile.%d{yyyy-MM-dd}.log</fileNamePattern>
             <maxHistory>30</maxHistory>
@@ -34,8 +30,6 @@
         <encoder>
             <pattern>%-4relative [%thread] %-5level %logger{35} - %msg%n</pattern>
         </encoder>
-
-        <!-- 메시지 필터 설정 -->
         <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
             <evaluator class="ch.qos.logback.classic.boolex.JaninoEventEvaluator">
                 <expression>message.contains("[INVALID")</expression>
@@ -44,7 +38,6 @@
             <onMismatch>DENY</onMismatch>
         </filter>
     </appender>
-
 
     <!-- INFO 이상 모든 로그를 기록할 Appender -->
     <appender name="ALL_LOG" class="ch.qos.logback.core.rolling.RollingFileAppender">


### PR DESCRIPTION
### ✅ 작업 내용
- **infra: docker compose log volume 추가**
  - Docker Compose 설정에 로그를 저장하기 위한 Volume 추가 작업을 진행하였습니다.
- **infra: log 필터 사용 후 수집 logback.xml**
  - Logback 설정에서 특정 로그 필터링 및 수집 기능을 구현하였습니다.
  - `[NEW` 또는 `[INVALID` 등의 키워드를 포함하는 로그를 별도 파일에 저장하도록 수정하였습니다.
- **infra: promtail config 추가**
  - Promtail 설정 파일을 추가하여 로그 수집 및 전송 구성을 완료하였습니다.
  - Loki와 연동하여 로그 모니터링을 효율적으로 할 수 있도록 설정을 구성하였습니다.

### 🤔 고민 했던 부분
- **Docker Compose에서 로그 Volume을 관리하는 방식**
  - 로그 데이터를 효과적으로 관리하기 위해 Volume을 사용하는 것이 적합한지 고민했습니다.
  - 컨테이너 종료 후에도 로그 데이터를 유지할 수 있도록 Volume 사용을 결정했습니다.
- **Logback 필터링 방식**
  - 특정 키워드 기반으로 로그를 수집하는 방식과 효율성을 고민하였습니다.
  - `EvaluatorFilter`를 사용하여 조건부 로그 수집을 구현하였으며, 조건 성능에 영향을 미치지 않는다고 판단하여 적용하였습니다.
- **Promtail과 Loki의 연동**
  - Promtail이 적절히 로그를 수집하고 Loki로 전송하기 위해 설정 값과 경로를 어떻게 관리할지 고민했습니다.
  - Promtail 설정을 컨테이너화하여 유연하게 관리하도록 구성했습니다.

### 🔊 도움이 필요한 부분
- **Promtail 로그 필터링**
  - 현재 Promtail에서 모든 로그를 Loki로 전송 중인데, 특정 로그만 전송하는 방식으로 개선이 필요할지 팀원의 의견을 듣고 싶습니다.
- **Logback 설정 추가 작업**
  - Logback 설정에서 추가적으로 필요한 로그 필터링 조건이 있는지 의견을 부탁드립니다. 
  - 현재는 `[NEW`와 `[INVALID` 키워드만 수집 중입니다.
